### PR TITLE
fix(graph): гигиена brand_related — мёртвые рёбра, транзакция, добор похожих

### DIFF
--- a/src/Command/BuildLinkGraphCommand.php
+++ b/src/Command/BuildLinkGraphCommand.php
@@ -43,25 +43,30 @@ class BuildLinkGraphCommand extends Command
     protected function configure(): void
     {
         $this->addOption('rebuild', null, InputOption::VALUE_NONE, 'Снести граф и построить заново');
+        $this->addOption('dead-only', null, InputOption::VALUE_NONE, 'Только чистка мёртвых рёбер + балансировка in-degree (без Qdrant) — для крона на проде');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = new SymfonyStyle($input, $output);
+        $deadOnly = (bool) $input->getOption('dead-only');
 
         if ($input->getOption('rebuild')) {
             $this->db->executeStatement('DELETE FROM brand_related');
             $io->warning('Граф снесён (--rebuild).');
         }
 
+        // --- Этап 1: исходящие рёбра (embedding → SQL fallback) ---
+        // Пропускаем при --dead-only: этап требует Qdrant (на проде его нет — граф
+        // строится офлайн на LLM-сервере и доезжает агент-API; на проде нужна только чистка).
+        $embedded = $fallback = $skipped = 0;
+        if (!$deadOnly) {
         $activeIds = array_map('intval', $this->db->fetchFirstColumn(
             "SELECT id FROM brand WHERE status = 'active' ORDER BY id",
         ));
         $activeSet = array_flip($activeIds);
         $io->text(sprintf('Активных брендов: %d', count($activeIds)));
 
-        // --- Этап 1: исходящие рёбра (embedding → SQL fallback) ---
-        $embedded = $fallback = $skipped = 0;
         foreach ($activeIds as $i => $brandId) {
             if ($this->graph->outDegree($brandId) >= BrandLinkGraphService::OUT_DEGREE) {
                 $skipped++;
@@ -91,6 +96,7 @@ class BuildLinkGraphCommand extends Command
             }
         }
         $io->text(sprintf('Исходящие: embedding %d · fallback %d · уже полные %d', $embedded, $fallback, $skipped));
+        }
 
         // --- Этап 2: рёбра на неактивные + гарантия входящих ---
         $dead = $this->graph->replaceDeadEdges();

--- a/src/Controller/Brands/BrandsController.php
+++ b/src/Controller/Brands/BrandsController.php
@@ -16,6 +16,9 @@ use Symfony\Component\Routing\Annotation\Route;
 
 class BrandsController extends AbstractController
 {
+    /** Минимум ссылок в блоке «похожие бренды» — чтобы страница не была тупиком для PageRank. */
+    private const MIN_SIMILAR_BRANDS = 6;
+
     #[Route('/{_locale}/brands', name: 'brand_index', requirements: ['_locale' => 'en|ru|zh|ar|tr|de|fr|es|ko'], defaults: ['_locale' => 'ru'])]
     public function brand_index(Request $request, BrandRepository $repo): Response
     {
@@ -260,8 +263,23 @@ class BrandsController extends AbstractController
         }
 
         $demoProducts = $this->createDemoProducts($brand);
-        // Жёсткий граф перелинковки; динамический подбор — только пока граф не построен
-        $similarBrands = $brandRepo->findRelatedHard($brand) ?: $brandRepo->findSimilarBrands($brand, 8);
+        // Жёсткий граф перелинковки (только active-таргеты). Если граф дал недобор
+        // (часть рёбер ведёт на ещё не опубликованные new-бренды → отфильтрованы),
+        // добиваем до минимума active-кандидатами, чтобы страница не становилась
+        // тупиком для внутреннего PageRank. Добор детерминирован (created_at DESC).
+        $similarBrands = $brandRepo->findRelatedHard($brand);
+        if (count($similarBrands) < self::MIN_SIMILAR_BRANDS) {
+            $seen = array_map(static fn ($b) => $b->getId(), $similarBrands);
+            foreach ($brandRepo->findSimilarBrands($brand, self::MIN_SIMILAR_BRANDS + count($seen)) as $cand) {
+                if (count($similarBrands) >= self::MIN_SIMILAR_BRANDS) {
+                    break;
+                }
+                if (!in_array($cand->getId(), $seen, true)) {
+                    $similarBrands[] = $cand;
+                    $seen[] = $cand->getId();
+                }
+            }
+        }
 
         $brandStyles = $brand->getStyles()->toArray();
         $brandCity = $brand->getCity();

--- a/src/Service/Agent/BrandIngestService.php
+++ b/src/Service/Agent/BrandIngestService.php
@@ -362,28 +362,34 @@ class BrandIngestService
     private function replaceRelated(Brand $brand, array $rows): void
     {
         $db = $this->em->getConnection();
-        $db->executeStatement('DELETE FROM brand_related WHERE brand_id = :id', ['id' => $brand->getId()]);
 
-        foreach (array_slice($rows, 0, \App\Service\BrandLinkGraphService::OUT_DEGREE) as $row) {
-            $slug = trim((string) ($row['slug'] ?? ''));
-            $position = (int) ($row['position'] ?? 0);
-            if ($slug === '' || $slug === $brand->getSlug() || $position < 1) {
-                continue;
+        // DELETE + повторная вставка — в одной транзакции: иначе при сбое (или
+        // наложении weave() из publish-tick на тот же brand_id) бренд может
+        // остаться с пустыми исходящими рёбрами между DELETE и INSERT.
+        $db->transactional(function () use ($db, $brand, $rows): void {
+            $db->executeStatement('DELETE FROM brand_related WHERE brand_id = :id', ['id' => $brand->getId()]);
+
+            foreach (array_slice($rows, 0, \App\Service\BrandLinkGraphService::OUT_DEGREE) as $row) {
+                $slug = trim((string) ($row['slug'] ?? ''));
+                $position = (int) ($row['position'] ?? 0);
+                if ($slug === '' || $slug === $brand->getSlug() || $position < 1) {
+                    continue;
+                }
+                $targetId = $db->fetchOne('SELECT id FROM brand WHERE slug = :slug', ['slug' => $slug]);
+                if ($targetId === false) {
+                    continue;
+                }
+                $db->executeStatement(
+                    'INSERT IGNORE INTO brand_related (brand_id, related_brand_id, position, source)
+                     VALUES (:brand, :related, :pos, :source)',
+                    [
+                        'brand'   => $brand->getId(),
+                        'related' => (int) $targetId,
+                        'pos'     => min($position, \App\Service\BrandLinkGraphService::OUT_DEGREE),
+                        'source'  => mb_substr((string) ($row['source'] ?? 'embedding'), 0, 20),
+                    ],
+                );
             }
-            $targetId = $db->fetchOne('SELECT id FROM brand WHERE slug = :slug', ['slug' => $slug]);
-            if ($targetId === false) {
-                continue;
-            }
-            $db->executeStatement(
-                'INSERT IGNORE INTO brand_related (brand_id, related_brand_id, position, source)
-                 VALUES (:brand, :related, :pos, :source)',
-                [
-                    'brand'   => $brand->getId(),
-                    'related' => (int) $targetId,
-                    'pos'     => min($position, \App\Service\BrandLinkGraphService::OUT_DEGREE),
-                    'source'  => mb_substr((string) ($row['source'] ?? 'embedding'), 0, 20),
-                ],
-            );
-        }
+        });
     }
 }

--- a/src/Service/BrandLinkGraphService.php
+++ b/src/Service/BrandLinkGraphService.php
@@ -259,13 +259,24 @@ class BrandLinkGraphService
      */
     public function replaceDeadEdges(): int
     {
+        // Сторона ИСТОЧНИКА: ребро ИЗ non-active бренда. На рендере не участвует
+        // (страница источника отдаёт 404), но искажает inDegree таргета — активный
+        // бренд думает, что входящих хватает, хотя одно ведёт с мёртвой страницы.
+        // Источник станет active → weave() пересоберёт его исходящие, поэтому удаляем.
+        // Делаем первым, чтобы ниже не тратить fallback-подбор на рёбра мёртвых источников.
+        $replaced = (int) $this->db->executeStatement(
+            "DELETE r FROM brand_related r JOIN brand b ON b.id = r.brand_id
+             WHERE b.status != 'active'",
+        );
+
+        // Сторона ТАРГЕТА: ребро НА non-active бренд — заменяем живым кандидатом
+        // (источник сохраняет out-degree), а если кандидата нет — удаляем.
         $dead = $this->db->fetchAllAssociative(
             "SELECT r.id, r.brand_id FROM brand_related r
              JOIN brand b ON b.id = r.related_brand_id
              WHERE b.status != 'active'",
         );
 
-        $replaced = 0;
         foreach ($dead as $edge) {
             $brandId = (int) $edge['brand_id'];
             $linked  = array_map('intval', $this->db->fetchFirstColumn(


### PR DESCRIPTION
## Контекст
Направленный граф перелинковки `brand_related` накапливал рёбра на/из non-active брендов (дрип new→active постепенный: 2588 new vs 446 active). Рендер их прятал (`findRelatedHard` фильтрует active — проверено на проде), но в БД они копились → Ahrefs видел ссылки на 404 (31 страница, ~5510 ссылок) и страницы с малым числом исходящих.

Решение валидировано тремя агентами (backend/db/seo): рендер уже корректен, нужна гигиена данных + защита от недобора. Полную машину состояний отложили (отдельная задача).

## Изменения
- **`replaceDeadEdges`** — добавлена сторона ИСТОЧНИКА: рёбра из non-active удаляются (искажали inDegree таргета). FK уже `ON DELETE CASCADE`, поэтому сироты от хард-делита не копятся.
- **`replaceRelated`** — DELETE+INSERT в транзакции (гонка с `weave()` из publish-tick могла оставить бренд без исходящих).
- **`BrandsController::show`** — добор похожих до `MIN_SIMILAR_BRANDS=6` active-кандидатами при недоборе (рёбра на ещё-new таргеты отфильтрованы) → не тупик для PageRank.
- **`--dead-only`** в `build-link-graph` — чистка+балансировка без Qdrant, для крона на проде.

## Проверка
- `php -l` все 4 файла — OK
- `app:brand:build-link-graph --dead-only` локально — отработал без Qdrant, сирот нет
- страница бренда — HTTP 200, 12 similar-ссылок
- падения phpunit предсуществующие (тест-БД), не связаны с правками

🤖 Generated with [Claude Code](https://claude.com/claude-code)