### PR TITLE
feat(brand): машина состояний статуса в доменных методах + убраны сырые UPDATE

### DIFF
--- a/src/Command/ImportBrandMediaCommand.php
+++ b/src/Command/ImportBrandMediaCommand.php
@@ -211,7 +211,7 @@ class ImportBrandMediaCommand extends Command
         }
 
         $brand->setDescription($productData['props']['pageProps']['brand']['description'] ?? '');
-        $brand->setStatus(Statuses::Active);
+        $brand->publish();   // доменный переход → active (published_at = МСК now)
         $this->alphabetManagerService->handleBrandUpdate($brand);
 
         return $result;

--- a/src/Command/PublishTickCommand.php
+++ b/src/Command/PublishTickCommand.php
@@ -4,7 +4,6 @@ namespace App\Command;
 
 use App\Entity\Brand;
 use Doctrine\ORM\EntityManagerInterface;
-use Nevinny\AdminCoreBundle\Enum\Statuses;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -172,10 +171,9 @@ class PublishTickCommand extends Command
             if ($brand === null) {
                 continue;
             }
-            $brand->setStatus(Statuses::Active)
-                ->setPublishPending(false)
-                // МСК, как и граница дня в published_today — иначе на UTC-проде счёт съезжает на 3ч
-                ->setPublishedAt(new \DateTime('now', $tz));
+            // Доменный переход new → active. МСК, как и граница дня в published_today —
+            // иначе на UTC-проде счёт published_today съезжает на 3ч.
+            $brand->publish(new \DateTime('now', $tz));
             $this->em->flush();
 
             // Вплетение в жёсткий граф перелинковки: исходящие рёбра + гарантия

--- a/src/Controller/Admin/RagDashboardController.php
+++ b/src/Controller/Admin/RagDashboardController.php
@@ -317,9 +317,14 @@ class RagDashboardController extends AbstractController
             );
             $this->addFlash('success', "Бренд #{$id} отправлен на переобогащение");
         } else { // hide
-            // Soft-hide локально (политика soft-delete) + снятие с публикации на проде.
-            $slug = (string) $this->db->fetchOne("SELECT slug FROM brand WHERE id=:id", ['id' => $id]);
-            $this->db->executeStatement("UPDATE brand SET status='disabled', publish_pending=0 WHERE id=:id", ['id' => $id]);
+            // Soft-hide локально (доменный переход brand->unpublish(), политика soft-delete)
+            // + снятие с публикации на проде.
+            $brand = $this->em->find(\App\Entity\Brand::class, (int) $id);
+            $slug = (string) ($brand?->getSlug() ?? '');
+            if ($brand !== null) {
+                $brand->unpublish();
+                $this->em->flush();
+            }
             $this->db->executeStatement("UPDATE brand_rag_pipeline SET last_error='review: скрыт вручную' WHERE brand_id=:id", ['id' => $id]);
             $this->addFlash('success', "Бренд #{$id} скрыт из каталога");
 

--- a/src/Entity/Brand.php
+++ b/src/Entity/Brand.php
@@ -11,6 +11,7 @@ use Nevinny\AdminCoreBundle\Entity\Trait\Created;
 use Nevinny\AdminCoreBundle\Entity\Trait\DefaultFields;
 use Nevinny\AdminCoreBundle\Entity\Trait\Owner;
 use Nevinny\AdminCoreBundle\Entity\Trait\Status;
+use Nevinny\AdminCoreBundle\Enum\Statuses;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 use Vich\UploaderBundle\Mapping\Annotation as Vich;
 use Symfony\Component\HttpFoundation\File\File;
@@ -822,6 +823,67 @@ class Brand
     public function setPublishedAt(?\DateTimeInterface $at): static
     {
         $this->publishedAt = $at;
+
+        return $this;
+    }
+
+    // ─── Машина состояний бренда: доменные переходы статуса ───────────────────
+    // Инвариант перехода держим здесь (по образцу BrandRagPipeline::markEmbedded —
+    // «setStatus() напрямую размазывал машину состояний, инварианты не держались»).
+    // Побочные эффекты (граф перелинковки, прод-синк, IndexNow) — на стороне
+    // вызывающих: они контекстно-зависимы (fail-open weave в дрипе vs транзакция
+    // в агент-ingest), и засовывать их в общий метод протекло бы абстракцией.
+
+    /** В очередь дрип-публикации: → new (создание/возврат в очередь). */
+    public function queue(): static
+    {
+        $this->setStatus(Statuses::New);
+        $this->publishPending = true;
+
+        return $this;
+    }
+
+    /**
+     * Опубликовать: new|disabled → active. Идемпотентно (повтор на active — no-op).
+     *
+     * @param \DateTimeInterface|null $at время публикации; по умолчанию — сейчас по МСК
+     *        (publish-tick считает published_today по нему — иначе на UTC-проде счёт съезжает на 3ч).
+     * @return bool true, если статус реально сменился
+     * @throws \DomainException из deleted/system публиковать нельзя (нужно явное восстановление)
+     */
+    public function publish(?\DateTimeInterface $at = null): bool
+    {
+        $status = $this->getStatus();
+        if ($status === Statuses::Active) {
+            return false;
+        }
+        if (!in_array($status, [Statuses::New, Statuses::Disabled], true)) {
+            throw new \DomainException(sprintf('Нельзя опубликовать бренд из статуса "%s"', $status?->value ?? 'null'));
+        }
+        $this->setStatus(Statuses::Active);
+        $this->publishPending = false;
+        $this->publishedAt = $at ?? new \DateTime('now', new \DateTimeZone('Europe/Moscow'));
+
+        return true;
+    }
+
+    /** Снять с публикации: → disabled. Идемпотентно (повтор на disabled — no-op). */
+    public function unpublish(): bool
+    {
+        if ($this->getStatus() === Statuses::Disabled) {
+            return false;
+        }
+        $this->setStatus(Statuses::Disabled);
+        $this->publishPending = false;
+
+        return true;
+    }
+
+    /** Мягкое удаление: → deleted (политика проекта — без физического DELETE). */
+    public function softDelete(): static
+    {
+        $this->setStatus(Statuses::Deleted);
+        $this->publishPending = false;
 
         return $this;
     }

--- a/src/Service/Agent/BrandIngestService.php
+++ b/src/Service/Agent/BrandIngestService.php
@@ -50,10 +50,7 @@ class BrandIngestService
             }
 
             if ($isNew) {
-                $brand = (new Brand())
-                    ->setSlug($slug)
-                    ->setStatus(Statuses::New)   // скрыт до дрип-публикации (каталог фильтрует active)
-                    ->setPublishPending(true);
+                $brand = (new Brand())->setSlug($slug)->queue();   // → new, скрыт до дрип-публикации
                 $this->em->persist($brand);
             }
 
@@ -168,8 +165,7 @@ class BrandIngestService
                 return ['status' => 'not_found', 'brand_id' => null];
             }
 
-            $brand->setStatus(Statuses::Disabled)
-                ->setPublishPending(false);
+            $brand->unpublish();
             $this->em->flush();
 
             return ['status' => 'unpublished', 'brand_id' => $brand->getId()];
@@ -207,9 +203,7 @@ class BrandIngestService
                 return ['status' => 'already_published', 'brand_id' => $brand->getId(), 'url' => $url];
             }
 
-            $brand->setStatus(Statuses::Active)
-                ->setPublishPending(false)
-                ->setPublishedAt(new \DateTime('now', new \DateTimeZone('Europe/Moscow')));
+            $brand->publish();   // new|disabled → active, published_at = МСК now
             $this->em->flush();
 
             return ['status' => 'published', 'brand_id' => $brand->getId(), 'url' => $url];

--- a/src/Service/Agent/BrandUnpublisher.php
+++ b/src/Service/Agent/BrandUnpublisher.php
@@ -4,7 +4,6 @@ namespace App\Service\Agent;
 
 use App\Entity\Brand;
 use Doctrine\ORM\EntityManagerInterface;
-use Nevinny\AdminCoreBundle\Enum\Statuses;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
@@ -44,8 +43,8 @@ class BrandUnpublisher
         $slug  = (string) $brand->getSlug();
 
         // 1) Локальный soft-hide (никогда не физический DELETE — политика проекта).
-        // Статус — backed-enum Statuses; «скрыт» = Disabled (как в agent-API unpublish).
-        $brand->setStatus(Statuses::Disabled)->setPublishPending(false);
+        // «Скрыт» = Disabled (доменный переход brand->unpublish(), как в agent-API unpublish).
+        $brand->unpublish();
         $this->em->flush();
 
         // 2) Снять с прод-каталога.

--- a/tests/Entity/BrandStatusTest.php
+++ b/tests/Entity/BrandStatusTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Entity;
+
+use App\Entity\Brand;
+use Nevinny\AdminCoreBundle\Enum\Statuses;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Машина состояний бренда: инварианты доменных переходов (без БД).
+ */
+class BrandStatusTest extends TestCase
+{
+    public function testQueueSetsNewAndPending(): void
+    {
+        $b = (new Brand())->queue();
+        $this->assertSame(Statuses::New, $b->getStatus());
+        $this->assertTrue($b->isPublishPending());
+    }
+
+    public function testPublishFromNew(): void
+    {
+        $b = (new Brand())->queue();
+        $this->assertTrue($b->publish());
+        $this->assertSame(Statuses::Active, $b->getStatus());
+        $this->assertFalse($b->isPublishPending());
+        $this->assertNotNull($b->getPublishedAt());
+    }
+
+    public function testPublishFromDisabled(): void
+    {
+        $b = new Brand();
+        $b->setStatus(Statuses::Disabled);
+        $this->assertTrue($b->publish());
+        $this->assertSame(Statuses::Active, $b->getStatus());
+    }
+
+    public function testPublishIdempotentOnActive(): void
+    {
+        $b = new Brand();
+        $b->setStatus(Statuses::Active);
+        $this->assertFalse($b->publish(), 'повтор publish на active — no-op');
+        $this->assertSame(Statuses::Active, $b->getStatus());
+    }
+
+    public function testPublishUsesGivenTimestamp(): void
+    {
+        $at = new \DateTime('2026-01-02 03:04:05');
+        $b = (new Brand())->queue();
+        $b->publish($at);
+        $this->assertSame($at, $b->getPublishedAt());
+    }
+
+    public function testPublishFromDeletedThrows(): void
+    {
+        $b = new Brand();
+        $b->setStatus(Statuses::Deleted);
+        $this->expectException(\DomainException::class);
+        $b->publish();
+    }
+
+    public function testUnpublishFromActive(): void
+    {
+        $b = new Brand();
+        $b->setStatus(Statuses::Active);
+        $this->assertTrue($b->unpublish());
+        $this->assertSame(Statuses::Disabled, $b->getStatus());
+        $this->assertFalse($b->isPublishPending());
+    }
+
+    public function testUnpublishIdempotentOnDisabled(): void
+    {
+        $b = new Brand();
+        $b->setStatus(Statuses::Disabled);
+        $this->assertFalse($b->unpublish(), 'повтор unpublish на disabled — no-op');
+    }
+
+    public function testSoftDelete(): void
+    {
+        $b = (new Brand())->queue();
+        $b->softDelete();
+        $this->assertSame(Statuses::Deleted, $b->getStatus());
+        $this->assertFalse($b->isPublishPending());
+    }
+}


### PR DESCRIPTION
## Зачем
Статус бренда менялся в 8 местах напрямую (`setStatus`) + сырой `UPDATE brand SET status` в RagDashboard — машина состояний размазана, инварианты не держались (как было у `BrandRagPipeline` до `markEmbedded`).

## Что
Доменные guard-методы на `Brand` (инвариант перехода — в сущности, по образцу `BrandRagPipeline::markEmbedded`):
- `queue()` → new · `publish(?at)` → new\|disabled→active (идемпотентно, throw из deleted/system, published_at МСК) · `unpublish()` → disabled · `softDelete()` → deleted

Все колл-сайты переведены на доменные методы; сырой `UPDATE brand SET status='disabled'` в RagDashboard убран.

**Побочки оставлены в колл-сайтах** (weave/прод-синк/IndexNow) — они контекстно-зависимы (fail-open weave в дрипе vs транзакция в агент-ingest); общий сервис-менеджер протёк бы абстракцией на границе транзакции (по ревью backend-агента). Поэтому БЕЗ `BrandStatusManager` — чистая машина на доменных методах.

## Решения/границы
- **flock-лок дрипа уже есть** (`PublishTickCommand`) → гонка `ensureIncoming` закрыта, `LockableTrait` не нужен.
- **EasyAdmin** меняет статус формой напрямую — осознанный admin-override (не сырой SQL), guard там не навязываем.
- Агент-ingest = тот же код на проде → инвариант зеркалируется автоматически.

## Проверка
- `tests/Entity/BrandStatusTest.php` — 9 тестов на инварианты переходов (без БД), зелёные
- `php -l` все файлы OK · `cache:clear` (DI) OK · `publish-tick --dry-run` OK
- осиротевшие импорты `Statuses` убраны (BrandUnpublisher, PublishTickCommand)

🤖 Generated with [Claude Code](https://claude.com/claude-code)