### PR TITLE
feat(landing): форма for-brands спрашивает название бренда и ссылку

### DIFF
--- a/src/Controller/LandingController.php
+++ b/src/Controller/LandingController.php
@@ -158,6 +158,11 @@ class LandingController extends AbstractController
 
         $email = trim((string) $request->request->get('email', ''));
         $source = trim((string) $request->request->get('source', 'no-marketplace'));
+        // Название и ссылка — опциональны на уровне роута: форму `landing_lead` шлют три лендинга,
+        // и только `for-brands` спрашивает бренд (required в разметке). Без них лид всё равно пишем,
+        // иначе no-marketplace / marketplace-fees перестали бы собирать почту (sales_offer.md §11).
+        $brandName = trim((string) $request->request->get('brand_name', ''));
+        $website = trim((string) $request->request->get('website', ''));
 
         if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
             $this->addFlash('error', 'Введите корректный email');
@@ -166,6 +171,15 @@ class LandingController extends AbstractController
 
         $existing = $em->getRepository(LandingLead::class)->findOneBy(['email' => $email]);
         if ($existing) {
+            // Повторная заявка — не дублируем, но дозаполняем то, чего в прошлый раз не спросили.
+            if ($brandName !== '' && $existing->getBrandName() === null) {
+                $existing->setBrandName($brandName);
+            }
+            if ($website !== '' && $existing->getWebsite() === null) {
+                $existing->setWebsite($website);
+            }
+            $em->flush();
+
             $this->addFlash('info', 'Вы уже оставляли заявку — мы скоро свяжемся с вами');
             return $this->redirect($request->headers->get('referer', '/'));
         }
@@ -173,6 +187,8 @@ class LandingController extends AbstractController
         $lead = new LandingLead();
         $lead->setEmail($email);
         $lead->setSource($source);
+        $lead->setBrandName($brandName !== '' ? $brandName : null);
+        $lead->setWebsite($website !== '' ? $website : null);
         $em->persist($lead);
         $em->flush();
 
@@ -180,7 +196,7 @@ class LandingController extends AbstractController
             $notifier->getAdminEmail(),
             'Новый лид с лендинга — ' . $email,
             'new_lead',
-            ['email' => $email, 'source' => $source]
+            ['email' => $email, 'source' => $source, 'brandName' => $brandName, 'website' => $website]
         );
 
         $this->addFlash('success', 'Спасибо! Мы свяжемся с вами в ближайшее время.');

--- a/src/EventListener/AdminTelegramSubscriber.php
+++ b/src/EventListener/AdminTelegramSubscriber.php
@@ -71,7 +71,9 @@ class AdminTelegramSubscriber
 
             $entity instanceof LandingLead => "📨 <b>Лид с лендинга</b>\n"
                 . $this->e($entity->getEmail())
-                . ($entity->getSource() ? ' (' . $this->e((string) $entity->getSource()) . ')' : ''),
+                . ($entity->getSource() ? ' (' . $this->e((string) $entity->getSource()) . ')' : '')
+                . ($entity->getBrandName() ? "\nБренд: " . $this->e((string) $entity->getBrandName()) : '')
+                . ($entity->getWebsite() ? "\nСайт: " . $this->e((string) $entity->getWebsite()) : ''),
 
             $entity instanceof Order => "🛒 <b>Новый заказ</b> " . $this->e((string) $entity->getOrderNumber())
                 . "\nСумма: " . $this->e($entity->getTotalAmount()) . ' ₽',

--- a/templates/emails/new_lead.html.twig
+++ b/templates/emails/new_lead.html.twig
@@ -4,6 +4,8 @@
 <h2 style="margin-top:0;font-size:18px;">Новый лид с лендинга</h2>
 <p style="color:#555;line-height:1.6;">
     <strong>Email:</strong> {{ email }}<br>
-    <strong>Источник:</strong> {{ source }}
+    <strong>Источник:</strong> {{ source }}<br>
+    <strong>Бренд:</strong> {{ brandName|default('') ?: '—' }}<br>
+    <strong>Сайт/соцсеть:</strong> {{ website|default('') ?: '—' }}
 </p>
 {% endblock %}

--- a/templates/tailwind/landing/for-brands.html.twig
+++ b/templates/tailwind/landing/for-brands.html.twig
@@ -92,12 +92,23 @@
     <section id="register" class="bg-gray-50 py-20">
         <div class="container mx-auto px-4 text-center">
             <h2 class="text-3xl font-black mb-4">Начать легко</h2>
-            <p class="text-gray-500 mb-10">Оставьте почту — мы проведём регистрацию за 5 минут</p>
-            <form method="post" action="{{ path('landing_lead') }}" class="flex flex-col sm:flex-row gap-3 max-w-md mx-auto">
-                <input type="email" name="email" required placeholder="your@brand.ru" class="flex-1 px-5 py-3 rounded-full text-sm border border-gray-300 outline-none focus:border-black">
+            <p class="text-gray-500 mb-10">Название бренда, ссылка и почта — мы проверим, есть ли у нас ваша карточка, и ответим в тот же рабочий день</p>
+            <form method="post" action="{{ path('landing_lead') }}" class="rounded-2xl bg-white shadow-sm p-6 space-y-4 max-w-md mx-auto text-left">
+                <div>
+                    <label class="block text-[11px] font-semibold uppercase tracking-wider text-gray-500 mb-1" for="lead-brand-name">Название бренда</label>
+                    <input type="text" id="lead-brand-name" name="brand_name" required placeholder="Ваш бренд" class="w-full rounded-lg border border-gray-200 px-3 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-gray-900">
+                </div>
+                <div>
+                    <label class="block text-[11px] font-semibold uppercase tracking-wider text-gray-500 mb-1" for="lead-email">Email</label>
+                    <input type="email" id="lead-email" name="email" required placeholder="your@brand.ru" class="w-full rounded-lg border border-gray-200 px-3 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-gray-900">
+                </div>
+                <div>
+                    <label class="block text-[11px] font-semibold uppercase tracking-wider text-gray-500 mb-1" for="lead-website">Ссылка на сайт/соцсеть (опц.)</label>
+                    <input type="text" id="lead-website" name="website" placeholder="instagram.com/yourbrand" class="w-full rounded-lg border border-gray-200 px-3 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-gray-900">
+                </div>
                 <input type="hidden" name="source" value="for-brands">
                 <input type="hidden" name="_csrf_token" value="{{ csrf_token('landing_lead') }}">
-                <button type="submit" class="bg-black text-white font-bold px-6 py-3 rounded-full hover:bg-gray-800 transition text-sm">Отправить</button>
+                <button type="submit" class="w-full rounded-xl bg-gray-900 text-white font-semibold px-6 py-3 hover:bg-black transition text-sm">Отправить</button>
             </form>
         </div>
     </section>

--- a/tests/Controller/LandingLeadControllerTest.php
+++ b/tests/Controller/LandingLeadControllerTest.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Controller;
+
+use App\Entity\LandingLead;
+
+/**
+ * Форма сбора лидов `landing_lead` (POST /landing/lead) — общая для трёх лендингов.
+ * На `for-brands` она спрашивает название бренда и ссылку (квалификация, sales_offer.md §11),
+ * на no-marketplace / marketplace-fees — по-прежнему только email.
+ *
+ * Run: php -d memory_limit=512M bin/phpunit --filter LandingLead
+ */
+class LandingLeadControllerTest extends DatabaseDependentWebTestCase
+{
+    private array $fixtureEmails = [];
+
+    protected function tearDown(): void
+    {
+        if ($this->fixtureEmails !== []) {
+            $em = static::getContainer()->get('doctrine.orm.entity_manager');
+            $repo = $em->getRepository(LandingLead::class);
+            foreach ($this->fixtureEmails as $email) {
+                if (($lead = $repo->findOneBy(['email' => $email])) !== null) {
+                    $em->remove($lead);
+                }
+            }
+            $em->flush();
+            $this->fixtureEmails = [];
+        }
+        parent::tearDown();
+    }
+
+    public function testForBrandsFormAsksBrandNameAndWebsite(): void
+    {
+        $this->skipIfNoDatabase();
+        $client = static::createClient();
+
+        $crawler = $client->request('GET', '/ru/for-brands');
+
+        $this->assertResponseIsSuccessful();
+        $this->assertSelectorExists('form[action*="/landing/lead"] input[name="brand_name"][required]');
+        $this->assertSelectorExists('form[action*="/landing/lead"] input[name="website"]');
+        $this->assertCount(1, $crawler->filter('form[action*="/landing/lead"] input[name="source"][value="for-brands"]'));
+    }
+
+    public function testForBrandsLeadStoresBrandNameAndWebsite(): void
+    {
+        $this->skipIfNoDatabase();
+        $client = static::createClient();
+
+        $email = 'lead-brand-' . uniqid() . '@example.com';
+        $this->fixtureEmails[] = $email;
+
+        $crawler = $client->request('GET', '/ru/for-brands');
+        $client->submit($crawler->filter('form[action*="/landing/lead"]')->form([
+            'brand_name' => 'Тестовый Бренд',
+            'email' => $email,
+            'website' => 'instagram.com/testbrand',
+        ]));
+
+        $this->assertResponseStatusCodeSame(302);
+
+        $em = static::getContainer()->get('doctrine.orm.entity_manager');
+        $lead = $em->getRepository(LandingLead::class)->findOneBy(['email' => $email]);
+        $this->assertNotNull($lead);
+        $this->assertSame('for-brands', $lead->getSource());
+        $this->assertSame('Тестовый Бренд', $lead->getBrandName());
+        $this->assertSame('instagram.com/testbrand', $lead->getWebsite());
+    }
+
+    public function testEmailOnlyLeadStillAccepted(): void
+    {
+        $this->skipIfNoDatabase();
+        $client = static::createClient();
+
+        $email = 'lead-plain-' . uniqid() . '@example.com';
+        $this->fixtureEmails[] = $email;
+
+        $crawler = $client->request('GET', '/ru/without-marketplaces');
+        $client->submit($crawler->filter('form[action*="/landing/lead"]')->form(['email' => $email]));
+
+        $this->assertResponseStatusCodeSame(302);
+
+        $em = static::getContainer()->get('doctrine.orm.entity_manager');
+        $lead = $em->getRepository(LandingLead::class)->findOneBy(['email' => $email]);
+        $this->assertNotNull($lead);
+        $this->assertSame('no-marketplace', $lead->getSource());
+        $this->assertNull($lead->getBrandName());
+    }
+
+    public function testRepeatLeadFillsMissingBrandName(): void
+    {
+        $this->skipIfNoDatabase();
+        $client = static::createClient();
+
+        $email = 'lead-repeat-' . uniqid() . '@example.com';
+        $this->fixtureEmails[] = $email;
+
+        $crawler = $client->request('GET', '/ru/without-marketplaces');
+        $client->submit($crawler->filter('form[action*="/landing/lead"]')->form(['email' => $email]));
+
+        $crawler = $client->request('GET', '/ru/for-brands');
+        $client->submit($crawler->filter('form[action*="/landing/lead"]')->form([
+            'brand_name' => 'Дозаполненный Бренд',
+            'email' => $email,
+            'website' => 'example.com',
+        ]));
+
+        $em = static::getContainer()->get('doctrine.orm.entity_manager');
+        $em->clear();
+        $leads = $em->getRepository(LandingLead::class)->findBy(['email' => $email]);
+        $this->assertCount(1, $leads, 'Повторная заявка не должна создавать второй лид');
+        $this->assertSame('Дозаполненный Бренд', $leads[0]->getBrandName());
+        $this->assertSame('example.com', $leads[0]->getWebsite());
+    }
+}


### PR DESCRIPTION
## Зачем
Первый живой лид с `/ru/for-brands` пришёл с одним только email — ни бренда, ни ссылки, квалифицировать нечем. Форма `placement` эти поля спрашивает давно, `for-brands` — нет.

## Что сделано
- **Форма `for-brands`**: `brand_name` (required) + `website` (опц.), вёрстка по токенам карточки из CLAUDE.md.
- **`LandingController::leadCapture`**: пишет `brandName`/`website`. Повторная заявка тем же email не создаёт второй лид, но **дозаполняет пустые** поля. На уровне роута поля опциональны — тот же `POST /landing/lead` шлют `without-marketplaces` и `marketplace-fees`, где по-прежнему только email.
- **Уведомления**: TG (`AdminTelegramSubscriber`) и письмо админу (`new_lead.html.twig`) показывают бренд и ссылку.

## Тесты
`tests/Controller/LandingLeadControllerTest.php` — разметка формы, сохранение полей, email-only лид с другого лендинга, дозаполнение при повторе. Локально: **311 тестов OK**.