### PR TITLE
feat(ads): включить авторасстановку РСЯ (page-id 19612178)

### DIFF
--- a/templates/tailwind/_yandex_rsa.html.twig
+++ b/templates/tailwind/_yandex_rsa.html.twig
@@ -1,3 +1,4 @@
-<!-- Yandex.RTB -->
+<!-- Yandex.RTB + Autoplacement 19612178 -->
 <script>window.yaContextCb=window.yaContextCb||[]</script>
 <script src="https://yandex.ru/ads/system/context.js" async></script>
+<script data-page-id="19612178" src="https://yandex.ru/ads/system/ap-loader.js" async></script>


### PR DESCRIPTION
## Что

Включена **авторасстановка рекламы РСЯ** (page-id `19612178`).

Проверка текущего кода: загрузчик `context.js` уже стоял в `base.html.twig` (партиал `_yandex_rsa.html.twig`), плюс 4 ручных блока `R-A-19612178-1` (catalog/hub/brand/blog). Не хватало только `ap-loader.js` — добавлен.

## Изменение

Одна строка в `templates/tailwind/_yandex_rsa.html.twig`:
```html
<script data-page-id="19612178" src="https://yandex.ru/ads/system/ap-loader.js" async></script>
```

## Почему ручные блоки не удаляю

По [докам Яндекса](https://yandex.ru/adv/edu/rsya/rsya-start/rsya-3-urok) авторасстановка совместима с ручными RTB-блоками, **приоритет у ручных**. Удаление срезало бы выручку уже настроенных слотов. Авторасстановка добирает инвентарь на остальных публичных страницах; `app.html.twig` (auth/ЛК/корзина, noindex) — без рекламы, как и раньше.

🤖 Generated with [Claude Code](https://claude.com/claude-code)