### PR TITLE
fix: регистрация бренда отдавала 500 + команда ручной выдачи доступа в ЛК

### DIFF
--- a/src/Command/GrantBrandAccessCommand.php
+++ b/src/Command/GrantBrandAccessCommand.php
@@ -1,0 +1,160 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Command;
+
+use App\Entity\Brand;
+use App\Entity\BrandUser;
+use App\Entity\User;
+use App\Service\SubscriptionFactory;
+use Doctrine\ORM\EntityManagerInterface;
+use Nevinny\AdminCoreBundle\Enum\Statuses;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+use Symfony\Component\String\Slugger\SluggerInterface;
+
+/**
+ * Ручная выдача доступа в ЛК бренда — для лидов, которых обрабатываем руками
+ * (sales_offer.md §11). Делает то же, что самостоятельная регистрация
+ * `/register?brand=1`, но за человека: аккаунт + бренд + связь владельца + free-trial.
+ *
+ * Бренд заводится в статусе `new` (НЕ публикуется в каталоге) — название владелец
+ * поправит сам в /brand/settings. Пароль временный: печатается в вывод, передать
+ * владельцу отдельным каналом и попросить сменить.
+ *
+ * Идемпотентна: повторный запуск не дублирует бренд/связь, только переустанавливает пароль.
+ */
+#[AsCommand(
+    name: 'app:brand:grant-access',
+    description: 'Выдать доступ в ЛК бренда вручную (аккаунт + бренд-заготовка + временный пароль)',
+)]
+class GrantBrandAccessCommand extends Command
+{
+    public function __construct(
+        private readonly EntityManagerInterface $em,
+        private readonly UserPasswordHasherInterface $hasher,
+        private readonly SluggerInterface $slugger,
+        private readonly SubscriptionFactory $subscriptionFactory,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('email', null, InputOption::VALUE_REQUIRED, 'Email владельца (логин)')
+            ->addOption('title', null, InputOption::VALUE_REQUIRED, 'Название бренда (по умолчанию — из email)')
+            ->addOption('password', null, InputOption::VALUE_REQUIRED, 'Временный пароль (по умолчанию генерируется)');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $email = strtolower(trim((string) $input->getOption('email')));
+        if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
+            $io->error('Нужен корректный --email');
+            return Command::INVALID;
+        }
+
+        $password = (string) ($input->getOption('password') ?? '');
+        if ($password === '') {
+            $password = $this->generatePassword();
+        }
+
+        $userRepo = $this->em->getRepository(User::class);
+        $user = $userRepo->findOneBy(['email' => $email]);
+        $userIsNew = $user === null;
+
+        if ($userIsNew) {
+            $user = new User();
+            $user->setEmail($email);
+            $this->em->persist($user);
+        }
+
+        $user->setPassword($this->hasher->hashPassword($user, $password));
+        // Доступ выдан руками — верификацию email считаем пройденной, иначе владелец
+        // упрётся в баннер «подтвердите email» с токеном, которого ему никто не присылал.
+        if (!$user->isEmailVerified()) {
+            $user->setEmailVerifiedAt(new \DateTimeImmutable());
+        }
+        if (!in_array('ROLE_BRAND_MANAGER', $user->getRoles(), true)) {
+            $user->setRoles(['ROLE_BRAND_MANAGER']);
+        }
+
+        $brandUserRepo = $this->em->getRepository(BrandUser::class);
+        $existingLink = $brandUserRepo->findOneBy(['user' => $user]);
+
+        if ($existingLink !== null) {
+            $brand = $existingLink->getBrand();
+            $io->note(sprintf('Пользователь уже привязан к бренду «%s» — пересоздавать не буду, только пароль.', (string) $brand?->getTitle()));
+        } else {
+            $title = trim((string) $input->getOption('title'));
+            if ($title === '') {
+                // Бренд неизвестен (лид оставил только почту) — заготовка с понятным
+                // временным названием, владелец переименует в /brand/settings.
+                $title = 'Новый бренд ' . explode('@', $email)[0];
+            }
+
+            $brand = new Brand();
+            $brand->setTitle($title);
+            $brand->setSlug($this->uniqueSlug($title));
+            $brand->setStatus(Statuses::New);
+            $this->em->persist($brand);
+
+            $link = new BrandUser();
+            $link->setUser($user);
+            $link->setBrand($brand);
+            $link->setRole(BrandUser::ROLE_OWNER);
+            $link->setAcceptedAt(new \DateTimeImmutable());
+            $this->em->persist($link);
+
+            $this->subscriptionFactory->createFreeTrial($brand);
+        }
+
+        $this->em->flush();
+
+        $io->success($userIsNew ? 'Аккаунт создан' : 'Аккаунт найден, пароль переустановлен');
+        $io->definitionList(
+            ['Логин' => $email],
+            ['Временный пароль' => $password],
+            ['Вход' => 'https://wearbase.ru/login'],
+            ['Кабинет' => 'https://wearbase.ru/brand/dashboard'],
+            ['Бренд' => sprintf('«%s» (id %d, статус %s)', (string) $brand->getTitle(), (int) $brand->getId(), (string) $brand->getStatus()?->value)],
+        );
+        $io->warning('Пароль передать владельцу и попросить сменить: /forgot-password → письмо со ссылкой на новый пароль.');
+
+        return Command::SUCCESS;
+    }
+
+    private function uniqueSlug(string $title): string
+    {
+        $base = strtolower((string) $this->slugger->slug($title));
+        $slug = $base;
+        $i = 1;
+
+        while ($this->em->getRepository(Brand::class)->findOneBy(['slug' => $slug])) {
+            $slug = $base . '-' . $i++;
+        }
+
+        return $slug;
+    }
+
+    /** Читаемый временный пароль: без похожих символов, диктуется голосом. */
+    private function generatePassword(): string
+    {
+        $alphabet = 'abcdefghjkmnpqrstuvwxyzACDEFGHJKLMNPQRSTUVWXYZ23456789';
+        $out = '';
+        for ($i = 0; $i < 12; $i++) {
+            $out .= $alphabet[random_int(0, strlen($alphabet) - 1)];
+        }
+
+        return $out;
+    }
+}

--- a/src/Service/SubscriptionFactory.php
+++ b/src/Service/SubscriptionFactory.php
@@ -21,7 +21,11 @@ class SubscriptionFactory
 
     public function createFreeTrial(Brand $brand): Subscription
     {
-        $existing = $this->subscriptionRepo->findActiveByBrand($brand);
+        // Бренд может быть ещё не сброшен в БД (регистрация бренда персистит Brand и сразу
+        // просит триал в одной транзакции). Doctrine не умеет биндить сущность без id в DQL и
+        // бросает ORMInvalidArgumentException → регистрация падала в 500. Без id подписок
+        // существовать не может, поэтому поиск дубля просто пропускаем.
+        $existing = $brand->getId() !== null ? $this->subscriptionRepo->findActiveByBrand($brand) : null;
         if ($existing !== null) {
             return $existing;
         }

--- a/tests/Command/GrantBrandAccessCommandTest.php
+++ b/tests/Command/GrantBrandAccessCommandTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Command;
+
+use App\Entity\Brand;
+use App\Entity\BrandUser;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Nevinny\AdminCoreBundle\Enum\Statuses;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+/**
+ * Ручная выдача доступа в ЛК бренда (app:brand:grant-access, sales_offer.md §11):
+ * создаёт аккаунт с рабочим паролем, бренд-заготовку в статусе `new` (не в каталоге)
+ * и связь владельца. Повторный запуск не плодит бренды — только меняет пароль.
+ */
+class GrantBrandAccessCommandTest extends KernelTestCase
+{
+    private EntityManagerInterface $em;
+    private CommandTester $tester;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $this->em = self::getContainer()->get(EntityManagerInterface::class);
+        $this->em->beginTransaction();
+
+        $application = new Application(self::$kernel);
+        $this->tester = new CommandTester($application->find('app:brand:grant-access'));
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->em->getConnection()->isTransactionActive()) {
+            $this->em->rollback();
+        }
+        parent::tearDown();
+    }
+
+    public function testCreatesAccountBrandAndOwnerLink(): void
+    {
+        $email = 'grant-' . uniqid() . '@example.com';
+
+        $this->tester->execute(['--email' => $email, '--password' => 'TempPass123', '--title' => 'Ручной Бренд']);
+
+        $this->tester->assertCommandIsSuccessful();
+        $this->assertStringContainsString('TempPass123', $this->tester->getDisplay());
+
+        $user = $this->em->getRepository(User::class)->findOneBy(['email' => $email]);
+        $this->assertNotNull($user);
+        $this->assertContains('ROLE_BRAND_MANAGER', $user->getRoles());
+        $this->assertTrue($user->isEmailVerified(), 'Ручная выдача доступа считается подтверждённым email');
+        $this->assertTrue(
+            self::getContainer()->get(UserPasswordHasherInterface::class)->isPasswordValid($user, 'TempPass123'),
+            'Выданным паролем должно получаться войти',
+        );
+
+        $link = $this->em->getRepository(BrandUser::class)->findOneBy(['user' => $user]);
+        $this->assertNotNull($link);
+        $this->assertSame(BrandUser::ROLE_OWNER, $link->getRole());
+
+        $brand = $link->getBrand();
+        $this->assertSame('Ручной Бренд', $brand->getTitle());
+        $this->assertSame(Statuses::New, $brand->getStatus(), 'Бренд-заготовка не должна попадать в каталог');
+    }
+
+    public function testDefaultTitleDerivedFromEmail(): void
+    {
+        $email = 'noname-' . uniqid() . '@example.com';
+
+        $this->tester->execute(['--email' => $email]);
+
+        $this->tester->assertCommandIsSuccessful();
+        $user = $this->em->getRepository(User::class)->findOneBy(['email' => $email]);
+        $brand = $this->em->getRepository(BrandUser::class)->findOneBy(['user' => $user])->getBrand();
+        $this->assertStringContainsString('Новый бренд', (string) $brand->getTitle());
+    }
+
+    public function testSecondRunOnlyResetsPassword(): void
+    {
+        $email = 'repeat-' . uniqid() . '@example.com';
+
+        $this->tester->execute(['--email' => $email, '--password' => 'First123456']);
+        $this->tester->execute(['--email' => $email, '--password' => 'Second12345']);
+
+        $this->tester->assertCommandIsSuccessful();
+
+        $user = $this->em->getRepository(User::class)->findOneBy(['email' => $email]);
+        $this->assertCount(1, $this->em->getRepository(BrandUser::class)->findBy(['user' => $user]), 'Второй бренд создаваться не должен');
+        $this->assertTrue(
+            self::getContainer()->get(UserPasswordHasherInterface::class)->isPasswordValid($user, 'Second12345'),
+        );
+    }
+
+    public function testInvalidEmailRejected(): void
+    {
+        $this->tester->execute(['--email' => 'not-an-email']);
+
+        $this->assertSame(2, $this->tester->getStatusCode(), 'Некорректный email → INVALID');
+        $this->assertSame(0, count($this->em->getRepository(Brand::class)->findBy(['title' => 'Новый бренд not-an-email'])));
+    }
+}

--- a/tests/Controller/BrandRegistrationControllerTest.php
+++ b/tests/Controller/BrandRegistrationControllerTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Controller;
+
+use App\Entity\BrandUser;
+use App\Entity\Subscription;
+use App\Entity\User;
+
+/**
+ * Самостоятельная регистрация бренда `/register?brand=1` — главный путь в ЛК с лендинга
+ * for-brands (sales_offer.md §11.2-bis).
+ *
+ * Регрессия 2026-07-26: отдавала 500. SubscriptionFactory::createFreeTrial() искал активную
+ * подписку по ещё не сброшенному в БД Brand → Doctrine ORMInvalidArgumentException
+ * («Binding entities to query parameters only allowed for entities that have an identifier»).
+ * Тест держит весь путь: аккаунт + бренд + связь владельца + free-trial.
+ */
+class BrandRegistrationControllerTest extends DatabaseDependentWebTestCase
+{
+    public function testBrandRegistrationCreatesAccountBrandAndTrial(): void
+    {
+        $this->skipIfNoDatabase();
+        $client = static::createClient();
+
+        $crawler = $client->request('GET', '/register?brand=1');
+        $this->assertResponseIsSuccessful();
+
+        $email = 'brand-reg-' . uniqid() . '@example.com';
+        $client->request('POST', '/register?brand=1', [
+            'brand_registration_form' => [
+                'brandTitle' => 'Регистрационный Бренд',
+                'firstName' => 'Иван',
+                'email' => $email,
+                'plainPassword' => ['first' => 'Passw0rd!123', 'second' => 'Passw0rd!123'],
+                'agreeTerms' => '1',
+                '_token' => $crawler->filter('input[name="brand_registration_form[_token]"]')->attr('value'),
+            ],
+            // Turnstile рендерится JS-виджетом: в тесте поле отправляем вручную
+            // (dummy-ключи в .env.test — always-pass).
+            'cf-turnstile-response' => 'dummy',
+        ]);
+
+        $this->assertResponseStatusCodeSame(302, 'После регистрации пользователь логинится и редиректится');
+
+        $em = static::getContainer()->get('doctrine.orm.entity_manager');
+
+        $user = $em->getRepository(User::class)->findOneBy(['email' => $email]);
+        $this->assertNotNull($user, 'Аккаунт бренда должен создаваться');
+        $this->assertContains('ROLE_BRAND_MANAGER', $user->getRoles());
+
+        $link = $em->getRepository(BrandUser::class)->findOneBy(['user' => $user]);
+        $this->assertNotNull($link, 'Владелец должен быть привязан к бренду');
+        $this->assertSame(BrandUser::ROLE_OWNER, $link->getRole());
+        $this->assertSame('Регистрационный Бренд', $link->getBrand()->getTitle());
+
+        $subscription = $em->getRepository(Subscription::class)->findOneBy(['brand' => $link->getBrand()]);
+        $this->assertNotNull($subscription, 'Должна создаваться free-trial подписка');
+        $this->assertSame(Subscription::STATUS_TRIAL, $subscription->getStatus());
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -2,6 +2,7 @@
 
 use App\Entity\Currency;
 use App\Entity\Language;
+use App\Entity\Tariff;
 use App\Kernel;
 use Doctrine\ORM\Tools\SchemaTool;
 use Symfony\Component\Dotenv\Dotenv;
@@ -78,6 +79,22 @@ if (($_SERVER['APP_ENV'] ?? null) === 'test') {
                 ->setIsActive(true)
                 ->setIsDefault(true);
             $em->persist($ru);
+        }
+
+        // Free-тариф: без него регистрация бренда и app:brand:grant-access падают на
+        // SubscriptionFactory (assert «Free tariff not found»). На проде его ставит миграция.
+        if ($em->getRepository(Tariff::class)->count([]) === 0) {
+            $free = (new Tariff())
+                ->setName('Бесплатный')
+                ->setCode(Tariff::CODE_FREE)
+                ->setPriceRub('0.00')
+                ->setTrialDays(30)
+                ->setMaxProducts(10)
+                ->setMaxImages(5)
+                ->setHasAnalytics(false)
+                ->setHasPriority(false)
+                ->setIsActive(true);
+            $em->persist($free);
         }
 
         $em->flush();


### PR DESCRIPTION
## 🔴 Главное: `/register?brand=1` отдавал 500

Самостоятельная регистрация бренда — тот самый путь в ЛК, который вчера стал главным CTA лендинга `for-brands` (#33) — **падала целиком**. `SubscriptionFactory::createFreeTrial()` искал активную подписку по `Brand`, ещё не сброшенному в БД: Doctrine не умеет биндить сущность без identifier и бросает `ORMInvalidArgumentException`. Регистрация в этом виде существовала с 12.06 (`87e5d34`) — то есть ни один бренд не мог зарегистрироваться сам.

Фикс минимальный: без `id` подписок у бренда существовать не может → поиск дубля пропускаем.

## Ручная выдача доступа
`app:brand:grant-access --email=… [--title=…] [--password=…]` — то же, что регистрация, но за человека (для лидов, которых обрабатываем руками, sales_offer.md §11):
- аккаунт `ROLE_BRAND_MANAGER`, email считается подтверждённым (иначе владелец упрётся в баннер верификации с токеном, которого ему не присылали);
- **бренд-заготовка `status=new`** — не попадает в каталог/sitemap, название владелец меняет в `/brand/settings`; если `--title` не задан, берётся из email;
- связь владельца + free-trial; идемпотентна — повторный запуск только переустанавливает пароль;
- временный пароль печатается в вывод (12 символов без похожих знаков), передаём отдельным каналом.

## Тесты
- `BrandRegistrationControllerTest` — регрессия на весь путь: аккаунт + бренд + владелец + trial.
- `GrantBrandAccessCommandTest` — создание, дефолтное имя из email, идемпотентность, отказ на битом email.
- `tests/bootstrap.php` сидит free-тариф (на проде его ставит миграция) — без него оба пути падали на `assert`.

Локально **318 OK**.

## ⚠️ Отдельно, не в этом PR
Регистрация создаёт бренд со **статусом `active`** (дефолт трейта `Status`) — то есть карточка с одним лишь названием сразу публикуется в каталоге, минуя ниша-гейт и origin-гейт. Это дыра для мусора/иностранных брендов, но менять поведение публикации — продуктовое решение, оставляю на твоё слово.