### PR TITLE
feat(lk): пригласительное письмо с доступом (--send)

### DIFF
--- a/src/Command/GrantBrandAccessCommand.php
+++ b/src/Command/GrantBrandAccessCommand.php
@@ -7,6 +7,7 @@ namespace App\Command;
 use App\Entity\Brand;
 use App\Entity\BrandUser;
 use App\Entity\User;
+use App\Notification\EmailNotifier;
 use App\Service\SubscriptionFactory;
 use Doctrine\ORM\EntityManagerInterface;
 use Nevinny\AdminCoreBundle\Enum\Statuses;
@@ -41,6 +42,7 @@ class GrantBrandAccessCommand extends Command
         private readonly UserPasswordHasherInterface $hasher,
         private readonly SluggerInterface $slugger,
         private readonly SubscriptionFactory $subscriptionFactory,
+        private readonly EmailNotifier $emailNotifier,
     ) {
         parent::__construct();
     }
@@ -50,7 +52,8 @@ class GrantBrandAccessCommand extends Command
         $this
             ->addOption('email', null, InputOption::VALUE_REQUIRED, 'Email владельца (логин)')
             ->addOption('title', null, InputOption::VALUE_REQUIRED, 'Название бренда (по умолчанию — из email)')
-            ->addOption('password', null, InputOption::VALUE_REQUIRED, 'Временный пароль (по умолчанию генерируется)');
+            ->addOption('password', null, InputOption::VALUE_REQUIRED, 'Временный пароль (по умолчанию генерируется)')
+            ->addOption('send', null, InputOption::VALUE_NONE, 'Отправить владельцу пригласительное письмо с доступом');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -128,7 +131,23 @@ class GrantBrandAccessCommand extends Command
             ['Кабинет' => 'https://wearbase.ru/brand/dashboard'],
             ['Бренд' => sprintf('«%s» (id %d, статус %s)', (string) $brand->getTitle(), (int) $brand->getId(), (string) $brand->getStatus()?->value)],
         );
-        $io->warning('Пароль передать владельцу и попросить сменить: /forgot-password → письмо со ссылкой на новый пароль.');
+        if ($input->getOption('send')) {
+            // Письмо уходит через EmailNotifier → MAILER_DSN (на проде rusender+api).
+            // Ключ `email` в контексте запрещён (см. память/sales_offer §11.2-bis) — только login.
+            $this->emailNotifier->send(
+                $email,
+                'Доступ в кабинет бренда на WEARBASE',
+                'brand_access_granted',
+                [
+                    'login' => $email,
+                    'tempPassword' => $password,
+                    'brandTitle' => (string) $brand->getTitle(),
+                ],
+            );
+            $io->success('Пригласительное письмо отправлено на ' . $email);
+        } else {
+            $io->warning('Пароль передать владельцу и попросить сменить: /forgot-password → письмо со ссылкой на новый пароль. Отправить письмо автоматически: --send');
+        }
 
         return Command::SUCCESS;
     }

--- a/templates/emails/brand_access_granted.html.twig
+++ b/templates/emails/brand_access_granted.html.twig
@@ -1,0 +1,49 @@
+{% extends 'emails/base.html.twig' %}
+{% block email_title %}Доступ в кабинет бренда — WEARBASE{% endblock %}
+{% block email_content %}
+<h2 style="margin-top:0;font-size:18px;">Кабинет бренда готов</h2>
+<p style="color:#555;line-height:1.6;">Здравствуйте!</p>
+<p style="color:#555;line-height:1.6;">
+    Вы оставляли заявку на wearbase.ru — мы завели кабинет за вас, регистрацию проходить не нужно.
+    Вот доступ:
+</p>
+<table role="presentation" style="width:100%;border-collapse:collapse;margin:16px 0;">
+    <tr>
+        <td style="padding:8px 12px;background:#f7f7f7;color:#555;font-size:14px;width:150px;">Логин</td>
+        <td style="padding:8px 12px;background:#f7f7f7;color:#111;font-size:14px;"><strong>{{ login }}</strong></td>
+    </tr>
+    <tr>
+        <td style="padding:8px 12px;color:#555;font-size:14px;">Временный пароль</td>
+        <td style="padding:8px 12px;color:#111;font-size:14px;"><strong>{{ tempPassword }}</strong></td>
+    </tr>
+</table>
+<p style="text-align:center;">
+    <a href="{{ url('app_login') }}" class="btn">Войти в кабинет</a>
+</p>
+<p style="color:#555;line-height:1.6;">
+    <strong>Сразу смените пароль:</strong> он временный и передавался письмом. Сделать это можно на
+    странице <a href="{{ url('app_forgot_password_request') }}" style="color:#111;">восстановления пароля</a> —
+    придёт ссылка на установку своего.
+</p>
+<p style="color:#555;line-height:1.6;">
+    Карточка бренда пока называется «{{ brandTitle }}» и <strong>в каталоге не опубликована</strong> —
+    названия вашего бренда мы не знали. Переименуйте её в разделе «Настройки» кабинета, добавьте
+    описание, товары, контакты и ссылки на свой сайт. Комиссии с продаж нет: покупатель уходит к вам,
+    оплата идёт на реквизиты вашего юр.лица — деньги через себя мы не проводим.
+</p>
+<p style="color:#555;line-height:1.6;">
+    Чтобы помочь с публикацией, ответьте на два вопроса прямо письмом:
+</p>
+<ol style="color:#555;line-height:1.6;">
+    <li>Как называется бренд и где на него посмотреть — сайт или соцсеть?</li>
+    <li>Вы владелец бренда или представляете его?</li>
+</ol>
+<p style="color:#555;line-height:1.6;">
+    Если карточка вашего бренда у нас <strong>уже есть</strong> (в каталоге больше трёх тысяч), не
+    заводите вторую — пришлите название, мы привяжем существующую к вашему кабинету.
+</p>
+<p style="color:#888;font-size:13px;">
+    Вопросы удобнее в мессенджере — бот <a href="https://t.me/wearbase_bot" style="color:#111;">t.me/wearbase_bot</a>,
+    читаем лично. Если заявку оставляли не вы — просто ответьте на это письмо, и мы удалим кабинет.
+</p>
+{% endblock %}

--- a/tests/Command/GrantBrandAccessCommandTest.php
+++ b/tests/Command/GrantBrandAccessCommandTest.php
@@ -11,6 +11,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Nevinny\AdminCoreBundle\Enum\Statuses;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Bundle\FrameworkBundle\Test\MailerAssertionsTrait;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 
@@ -21,6 +22,8 @@ use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
  */
 class GrantBrandAccessCommandTest extends KernelTestCase
 {
+    use MailerAssertionsTrait;
+
     private EntityManagerInterface $em;
     private CommandTester $tester;
 
@@ -103,5 +106,37 @@ class GrantBrandAccessCommandTest extends KernelTestCase
 
         $this->assertSame(2, $this->tester->getStatusCode(), 'Некорректный email → INVALID');
         $this->assertSame(0, count($this->em->getRepository(Brand::class)->findBy(['title' => 'Новый бренд not-an-email'])));
+    }
+
+    public function testSendFlagMailsCredentials(): void
+    {
+        $email = 'invite-' . uniqid() . '@example.com';
+
+        $this->tester->execute([
+            '--email' => $email,
+            '--password' => 'TempPass123',
+            '--title' => 'Приглашённый Бренд',
+            '--send' => true,
+        ]);
+
+        $this->tester->assertCommandIsSuccessful();
+        $this->assertStringContainsString('письмо отправлено', $this->tester->getDisplay());
+
+        $this->assertEmailCount(1);
+        $message = $this->getMailerMessage();
+        $this->assertSame($email, $message->getTo()[0]->getAddress());
+        $body = $message->getHtmlBody();
+        $this->assertStringContainsString('TempPass123', $body, 'В письме должен быть временный пароль');
+        $this->assertStringContainsString($email, $body, 'В письме должен быть логин');
+        $this->assertStringContainsString('Приглашённый Бренд', $body);
+        $this->assertStringContainsString('/login', $body);
+    }
+
+    public function testWithoutSendFlagNoMailGoesOut(): void
+    {
+        $this->tester->execute(['--email' => 'silent-' . uniqid() . '@example.com']);
+
+        $this->tester->assertCommandIsSuccessful();
+        $this->assertEmailCount(0, 'Без --send письмо уходить не должно');
     }
 }


### PR DESCRIPTION
## Что
Флаг `--send` у `app:brand:grant-access` + шаблон `brand_access_granted`: владелец получает доступ письмом, а не через пересказ в мессенджере.

В письме: логин, временный пароль, кнопка входа, требование **сразу сменить пароль** через `/forgot-password`, честное «карточка пока не опубликована и называется так-то — переименуйте в Настройках», два вопроса на квалификацию (название + ссылка; владелец/представитель), просьба не заводить вторую карточку если бренд уже в каталоге, ТГ-бот и выход «заявку оставлял не я → удалим кабинет».

Отправка идёт `EmailNotifier` → `MAILER_DSN`, на проде это `rusender+api` — тот же канал, что остальные транзакционные письма. Ключ `email` в контекст не кладём (та самая грабля из #33).

## Тесты
`--send` → письмо ушло, в теле пароль/логин/название бренда/ссылка входа; без флага писем 0. Локально **320 OK**.