### PR TITLE
fix(mailer): все транзакционные письма молча не отправлялись

### DIFF
--- a/src/Command/GrantBrandAccessCommand.php
+++ b/src/Command/GrantBrandAccessCommand.php
@@ -134,7 +134,7 @@ class GrantBrandAccessCommand extends Command
         if ($input->getOption('send')) {
             // Письмо уходит через EmailNotifier → MAILER_DSN (на проде rusender+api).
             // Ключ `email` в контексте запрещён (см. память/sales_offer §11.2-bis) — только login.
-            $this->emailNotifier->send(
+            $sent = $this->emailNotifier->send(
                 $email,
                 'Доступ в кабинет бренда на WEARBASE',
                 'brand_access_granted',
@@ -144,6 +144,13 @@ class GrantBrandAccessCommand extends Command
                     'brandTitle' => (string) $brand->getTitle(),
                 ],
             );
+
+            if (!$sent) {
+                $io->error('Письмо НЕ отправлено — причина в логе (app.ERROR «Email notification failed»). Доступ выдан, пароль передать вручную.');
+
+                return Command::FAILURE;
+            }
+
             $io->success('Пригласительное письмо отправлено на ' . $email);
         } else {
             $io->warning('Пароль передать владельцу и попросить сменить: /forgot-password → письмо со ссылкой на новый пароль. Отправить письмо автоматически: --send');

--- a/src/Mailer/RusenderApiTransport.php
+++ b/src/Mailer/RusenderApiTransport.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace App\Mailer;
 
+use Psr\EventDispatcher\EventDispatcherInterface;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Mailer\Envelope;
 use Symfony\Component\Mailer\Exception\HttpTransportException;
 use Symfony\Component\Mailer\SentMessage;
 use Symfony\Component\Mailer\Transport\AbstractApiTransport;
 use Symfony\Component\Mime\Email;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
 /**
@@ -22,11 +25,20 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
  */
 final class RusenderApiTransport extends AbstractApiTransport
 {
+    /**
+     * ⚠️ Dispatcher обязателен к передаче наверх: именно на `MessageEvent` висит
+     * twig-рендерер тела (`BodyRenderer`). Без него любое `TemplatedEmail` доходит до
+     * транспорта БЕЗ html/text и падает с «A message must have a text or an HTML part»
+     * — то есть молча умирают все письма из EmailNotifier (регрессия 12.06–26.07.2026).
+     */
     public function __construct(
         private readonly string $apiKey,
         private readonly ?string $keyId = null,
+        ?HttpClientInterface $client = null,
+        ?EventDispatcherInterface $dispatcher = null,
+        ?LoggerInterface $logger = null,
     ) {
-        parent::__construct();
+        parent::__construct($client, $dispatcher, $logger);
     }
 
     public function __toString(): string

--- a/src/Mailer/RusenderTransportFactory.php
+++ b/src/Mailer/RusenderTransportFactory.php
@@ -17,9 +17,14 @@ final class RusenderTransportFactory extends AbstractTransportFactory
             throw new UnsupportedSchemeException($dsn, 'rusender', $this->getSupportedSchemes());
         }
 
+        // client/dispatcher/logger — из AbstractTransportFactory; dispatcher критичен:
+        // без него не рендерится тело TemplatedEmail (см. комментарий в транспорте).
         $transport = new RusenderApiTransport(
             $this->getUser($dsn),
             $dsn->getOption('key_id'),
+            $this->client,
+            $this->dispatcher,
+            $this->logger,
         );
 
         if ('default' !== $dsn->getHost()) {

--- a/src/Notification/EmailNotifier.php
+++ b/src/Notification/EmailNotifier.php
@@ -27,8 +27,12 @@ readonly class EmailNotifier
 
     /**
      * @param array<string, mixed> $context
+     *
+     * @return bool false — письмо НЕ ушло (ошибка залогирована). Вызовы, которым важен
+     *              факт отправки (ручные команды), обязаны проверять результат: soft-fail
+     *              иначе превращается в «отчитались об успехе, письма нет».
      */
-    public function send(User|string $recipient, string $subject, string $template, array $context = []): void
+    public function send(User|string $recipient, string $subject, string $template, array $context = []): bool
     {
         if ($recipient instanceof User) {
             $to = new Address((string) $recipient->getEmail(), $recipient->getFullName());
@@ -47,6 +51,8 @@ readonly class EmailNotifier
 
         try {
             $this->mailer->send($email);
+
+            return true;
         } catch (\Throwable $e) {
             // soft-fail: письмо не должно ронять заказ, но молчать об ошибке нельзя
             $this->logger->error('Email notification failed', [
@@ -55,6 +61,8 @@ readonly class EmailNotifier
                 'template' => $template,
                 'error' => $e->getMessage(),
             ]);
+
+            return false;
         }
     }
 }

--- a/tests/Mailer/RusenderApiTransportTest.php
+++ b/tests/Mailer/RusenderApiTransportTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Mailer;
+
+use App\Mailer\RusenderTransportFactory;
+use Symfony\Bridge\Twig\Mime\BodyRenderer;
+use Symfony\Bridge\Twig\Mime\TemplatedEmail;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Component\Mailer\EventListener\MessageListener;
+use Symfony\Component\Mailer\Transport\Dsn;
+use Symfony\Component\Mime\Address;
+use Twig\Environment;
+
+/**
+ * Транспорт Rusender + рендер тела письма.
+ *
+ * Регрессия 12.06–26.07.2026: транспорт вызывал `parent::__construct()` без dispatcher'а,
+ * поэтому `MessageEvent` не диспатчился, twig-рендерер (`BodyRenderer`) не срабатывал и любое
+ * `TemplatedEmail` доходило до API без html → «A message must have a text or an HTML part».
+ * Молча (soft-fail в EmailNotifier) умирали ВСЕ транзакционные письма: подтверждение email,
+ * коды заявок на бренд, сброс пароля, подтверждения заказов.
+ */
+class RusenderApiTransportTest extends KernelTestCase
+{
+    public function testTemplatedEmailReachesApiWithRenderedHtml(): void
+    {
+        self::bootKernel();
+
+        $requests = [];
+        $client = new MockHttpClient(function (string $method, string $url, array $options) use (&$requests) {
+            $requests[] = ['method' => $method, 'url' => $url, 'body' => $options['body'] ?? ''];
+
+            return new MockResponse('{"uuid":"test"}', ['http_code' => 200]);
+        });
+
+        // Диспетчер с тем же слушателем, что регистрирует framework-бандл: он и рендерит тело.
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addSubscriber(new MessageListener(
+            null,
+            new BodyRenderer(self::getContainer()->get(Environment::class)),
+        ));
+
+        $factory = new RusenderTransportFactory($dispatcher, $client);
+        $transport = $factory->create(Dsn::fromString('rusender+api://test-key@default?key_id=42'));
+
+        $email = (new TemplatedEmail())
+            ->from(new Address('hello@mail.wearbase.ru', 'WEARBASE'))
+            ->to(new Address('owner@example.com'))
+            ->subject('Доступ в кабинет бренда на WEARBASE')
+            ->htmlTemplate('emails/brand_access_granted.html.twig')
+            ->context([
+                'login' => 'owner@example.com',
+                'tempPassword' => 'TempPass123',
+                'brandTitle' => 'Тестовый Бренд',
+                'user' => (new \App\Entity\User())->setEmail('owner@example.com'),
+            ]);
+
+        $transport->send($email);
+
+        $this->assertCount(1, $requests, 'Транспорт должен сделать ровно один запрос к API');
+        $this->assertStringContainsString('/api/v1/external-mails/send/42', $requests[0]['url']);
+
+        $payload = json_decode((string) $requests[0]['body'], true, 512, JSON_THROW_ON_ERROR);
+        $this->assertArrayHasKey('html', $payload['mail'], 'Тело TemplatedEmail должно быть отрендерено до отправки');
+        $this->assertStringContainsString('TempPass123', $payload['mail']['html']);
+        $this->assertStringContainsString('Тестовый Бренд', $payload['mail']['html']);
+        $this->assertSame('owner@example.com', $payload['mail']['to']['email']);
+    }
+}


### PR DESCRIPTION
## 🔴 Масштаб
`RusenderApiTransport` вызывал `parent::__construct()` **без dispatcher'а**. На `MessageEvent` висит twig-рендерер тела (`BodyRenderer`) — без dispatcher'а он не срабатывает, `TemplatedEmail` доходит до API без html и падает с `A message must have a text or an HTML part`. `EmailNotifier` soft-fail'ил исключение в лог, поэтому снаружи это выглядело как «письма просто не приходят».

Под это попадали **все** письма из `EmailNotifier` с 12.06.2026 (`fb8a8b0`, появление транспорта): подтверждение email при регистрации, коды заявок на бренд, сброс пароля, подтверждения заказов и смены статуса, приглашения в команду бренда, newsletter-дайджест. Аутрич не пострадал — `BrandOutreachMailer` ходит в RuSender своим HTTP-клиентом, минуя Mailer.

Нашлось при отправке пригласительного письма лиду: команда отрапортовала успех, а в логе лежала эта ошибка.

## Фикс
- Фабрика передаёт `client` / `dispatcher` / `logger` в транспорт (в транспорте — комментарий, почему dispatcher критичен).
- `EmailNotifier::send()` возвращает `bool` — soft-fail больше не выглядит успехом для вызывающего.
- `app:brand:grant-access --send` возвращает `FAILURE`, если письмо не ушло, вместо зелёного «отправлено».

## Тест
`tests/Mailer/RusenderApiTransportTest` — `TemplatedEmail` через MockHttpClient доходит до `/api/v1/external-mails/send/{key_id}` с отрендеренным html. Проверил, что тест **падает ровно прод-ошибкой**, если убрать передачу dispatcher'а. Локально **321 OK**.

## После мержа
Повторно отправляю пригласительное письмо лиду и проверяю по логу, что ушло.