### PR TITLE
fix(mailer): дефолтный хост RuSender — beta-домен (api.rusender.ru даёт 401)

### DIFF
--- a/src/Mailer/RusenderApiTransport.php
+++ b/src/Mailer/RusenderApiTransport.php
@@ -22,6 +22,12 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
  * DSN: rusender+api://API_KEY@default[?key_id=4487]
  *  - key_id задан → POST /api/v1/external-mails/send/{key_id} (новый формат, Bearer)
  *  - без key_id   → POST /api/v1/external-mails/send (старый формат, X-Api-Key)
+ *
+ * ⚠️ Рабочая комбинация (проверено curl'ом с прода 2026-07-26, HTTP 201):
+ * host `api.beta.rusender.ru` + `X-Api-Key` + путь без key_id. Тот же ключ на
+ * `api.rusender.ru` (и с Bearer, и с X-Api-Key, и с /send/{key_id}) отдаёт
+ * 401 «Provided API token is invalid» — поэтому beta и есть дефолтный хост.
+ * Аутрич (BrandOutreachMailer) ходит туда же.
  */
 final class RusenderApiTransport extends AbstractApiTransport
 {
@@ -103,6 +109,6 @@ final class RusenderApiTransport extends AbstractApiTransport
 
     private function getEndpoint(): string
     {
-        return ($this->host ?: 'api.rusender.ru') . ($this->port ? ':' . $this->port : '');
+        return ($this->host ?: 'api.beta.rusender.ru') . ($this->port ? ':' . $this->port : '');
     }
 }

--- a/tests/Mailer/RusenderApiTransportTest.php
+++ b/tests/Mailer/RusenderApiTransportTest.php
@@ -71,4 +71,34 @@ class RusenderApiTransportTest extends KernelTestCase
         $this->assertStringContainsString('Тестовый Бренд', $payload['mail']['html']);
         $this->assertSame('owner@example.com', $payload['mail']['to']['email']);
     }
+
+    /**
+     * Дефолтный хост — beta-домен с X-Api-Key: единственная комбинация, которую RuSender
+     * принимает нашим ключом (api.rusender.ru отдаёт 401, проверено с прода 2026-07-26).
+     */
+    public function testDefaultHostIsBetaWithApiKeyHeader(): void
+    {
+        self::bootKernel();
+
+        $seen = [];
+        $client = new MockHttpClient(function (string $method, string $url, array $options) use (&$seen) {
+            $seen = ['url' => $url, 'headers' => $options['headers'] ?? []];
+
+            return new MockResponse('{"uuid":"test"}', ['http_code' => 201]);
+        });
+
+        $factory = new RusenderTransportFactory(new EventDispatcher(), $client);
+        $transport = $factory->create(Dsn::fromString('rusender+api://test-key@default'));
+
+        $transport->send(
+            (new \Symfony\Component\Mime\Email())
+                ->from(new Address('hello@mail.wearbase.ru', 'WEARBASE'))
+                ->to(new Address('owner@example.com'))
+                ->subject('probe')
+                ->html('<p>probe</p>')
+        );
+
+        $this->assertSame('https://api.beta.rusender.ru/api/v1/external-mails/send', $seen['url']);
+        $this->assertContains('X-Api-Key: test-key', $seen['headers']);
+    }
 }


### PR DESCRIPTION
Продолжение #37. После фикса рендера письмо реально ушло в API и получило **401 «Provided API token is invalid»**. Прогнал варианты curl'ом с прода: `api.beta.rusender.ru/api/v1/external-mails/send` + `X-Api-Key` → **201**; `api.rusender.ru` тем же ключом → 401 (и с Bearer, и с X-Api-Key, и с `/send/{key_id}`). Аутрич ходит туда же — совпадает.

Дефолтный хост транспорта → beta, комментарий с проверкой. Тест: DSN без `key_id` шлёт на beta-домен с `X-Api-Key`.

Прод-`MAILER_DSN` правлю отдельно (там прописан api.rusender.ru + key_id) — конфиг не в репозитории.