### PR TITLE
fix(mailer): From транзакционных писем — подтверждённый домен, Reply-To админу

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -33,6 +33,9 @@ MESSENGER_TRANSPORT_DSN=sync://
 
 ###> symfony/mailer ###
 MAILER_DSN=null://null
+# From транзакционных писем. Домен обязан быть подтверждён в RuSender: рабочий —
+# mail.wearbase.ru (hello@wearbase.ru отдаёт 404 «User Domain not found»). Пусто = дефолт кода.
+MAILER_FROM="WEARBASE <hello@mail.wearbase.ru>"
 ###< symfony/mailer ###
 
 ###> app/config ###

--- a/src/Notification/EmailNotifier.php
+++ b/src/Notification/EmailNotifier.php
@@ -13,16 +13,38 @@ use Symfony\Component\Mime\Address;
 
 readonly class EmailNotifier
 {
+    /**
+     * From обязан быть на домене, подтверждённом в RuSender: проверено с прода 2026-07-26 —
+     * `hello@mail.wearbase.ru` даёт 201, а `hello@wearbase.ru` и любой сторонний адрес
+     * (напр. ADMIN_EMAIL=nevinny@gmail.com, который стоял здесь раньше) — 404 «User Domain
+     * not found». ADMIN_EMAIL остаётся адресом ПОЛУЧАТЕЛЯ админских уведомлений и Reply-To.
+     */
+    private const DEFAULT_FROM = 'WEARBASE <hello@mail.wearbase.ru>';
+
     public function __construct(
         private MailerInterface $mailer,
         #[Autowire('%env(ADMIN_EMAIL)%')]
         private string $adminEmail,
         private LoggerInterface $logger,
+        #[Autowire('%env(default::MAILER_FROM)%')]
+        private ?string $from = null,
     ) {}
 
     public function getAdminEmail(): string
     {
         return $this->adminEmail;
+    }
+
+    /** "WEARBASE <hello@mail.wearbase.ru>" → Address; без имени тоже принимаем. */
+    private function fromAddress(): Address
+    {
+        $raw = trim((string) ($this->from ?: self::DEFAULT_FROM));
+
+        if (preg_match('/^(.*)<([^>]+)>$/', $raw, $m) === 1) {
+            return new Address(trim($m[2]), trim($m[1]));
+        }
+
+        return new Address($raw, 'WEARBASE');
     }
 
     /**
@@ -43,11 +65,17 @@ readonly class EmailNotifier
         }
 
         $email = (new TemplatedEmail())
-            ->from(new Address($this->adminEmail, 'WEARBASE'))
+            ->from($this->fromAddress())
             ->to($to)
             ->subject($subject)
             ->htmlTemplate("emails/{$template}.html.twig")
             ->context($context);
+
+        // Ответы владельцу, а не в noreply на поддомене рассылки: пригласительные и
+        // сервисные письма прямо просят ответить (название бренда, «это не я»).
+        if ($this->adminEmail !== '' && $to->getAddress() !== $this->adminEmail) {
+            $email->replyTo(new Address($this->adminEmail));
+        }
 
         try {
             $this->mailer->send($email);

--- a/tests/Notification/EmailNotifierTest.php
+++ b/tests/Notification/EmailNotifierTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Notification;
+
+use App\Notification\EmailNotifier;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Bundle\FrameworkBundle\Test\MailerAssertionsTrait;
+
+/**
+ * From транзакционных писем.
+ *
+ * Регрессия 2026-07-26: From брался из ADMIN_EMAIL (nevinny@gmail.com) — RuSender отвечал
+ * 404 «User Domain not found», потому что отправлять можно только с подтверждённого домена
+ * mail.wearbase.ru. Ответы при этом должны приходить владельцу → Reply-To = ADMIN_EMAIL.
+ */
+class EmailNotifierTest extends KernelTestCase
+{
+    use MailerAssertionsTrait;
+
+    public function testFromIsVerifiedDomainAndReplyToIsAdmin(): void
+    {
+        self::bootKernel();
+        $notifier = self::getContainer()->get(EmailNotifier::class);
+
+        $sent = $notifier->send('owner@example.com', 'Тема', 'lead_welcome', ['brandName' => 'Бренд']);
+
+        $this->assertTrue($sent, 'send() должен сообщать об успехе булевым результатом');
+        $this->assertEmailCount(1);
+
+        $message = $this->getMailerMessage();
+        $this->assertSame('hello@mail.wearbase.ru', $message->getFrom()[0]->getAddress());
+        $this->assertNotSame([], $message->getReplyTo(), 'Reply-To должен быть выставлен');
+        $this->assertSame($notifier->getAdminEmail(), $message->getReplyTo()[0]->getAddress());
+    }
+}


### PR DESCRIPTION
Третий и последний слой той же поломки писем (после #37 рендера и #38 хоста).

`EmailNotifier` ставил `From` из `ADMIN_EMAIL` = `nevinny@gmail.com` → RuSender: **404 «User Domain not found»**. Проверено curl'ом с прода: `hello@mail.wearbase.ru` → 201, `hello@wearbase.ru` → 404. Подтверждён только поддомен рассылки.

- `MAILER_FROM` с дефолтом `WEARBASE <hello@mail.wearbase.ru>`, разбор формата `Имя <email>`; задокументирован в `.env.dist`.
- `Reply-To = ADMIN_EMAIL` — пригласительное и сервисные письма прямо просят ответить (название бренда, «заявку оставлял не я»), ответы должны падать владельцу, а не в поддомен рассылки.
- Тест на From/Reply-To. Локально **323 OK**.

⚠️ На заметку: транзакционные письма теперь идут с того же поддомена, что аутрич (`mail.wearbase.ru`) — репутация общая. Если аутрич начнёт собирать жалобы, транзакционку стоит увести на отдельный подтверждённый поддомен.