### PR TITLE
feat(mailer): app:mail:test — дымовой тест транзакционных писем

### DIFF
--- a/src/Command/MailTestCommand.php
+++ b/src/Command/MailTestCommand.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Command;
+
+use App\Entity\Brand;
+use App\Notification\EmailNotifier;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * Дымовой тест транзакционной почты: реально отправляет шаблоны письма на указанный адрес
+ * через тот же {@see EmailNotifier}, которым шлёт приложение.
+ *
+ * Зачем отдельно от `mailer:test`: тот шлёт обычный `Email` с готовым текстом, ему НЕ нужен
+ * twig-рендер — именно поэтому 19.07.2026 он показывал «401, ключ отозван», пока настоящие
+ * `TemplatedEmail` падали раньше на пустом теле (docs/production.md, раздел почты).
+ * Здесь проверяется весь путь: рендер шаблона → From/Reply-To → транспорт → ответ API.
+ *
+ * Шаблоны, которым нужны реальные сущности (заказы, заявки, приглашения, дайджест),
+ * сюда не входят — они проверяются своими сценариями.
+ */
+#[AsCommand(
+    name: 'app:mail:test',
+    description: 'Отправить тестовые транзакционные письма на адрес (проверка рендера + доставки)',
+)]
+class MailTestCommand extends Command
+{
+    /** Шаблоны с простым контекстом — покрывают то, что ломалось. */
+    private const TEMPLATES = ['lead_welcome', 'brand_access_granted', 'new_lead', 'verify_email', 'reset_password', 'brand_claim_code'];
+
+    public function __construct(
+        private readonly EmailNotifier $notifier,
+        private readonly EntityManagerInterface $em,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addArgument('email', InputArgument::REQUIRED, 'Куда отправлять')
+            ->addOption('only', null, InputOption::VALUE_REQUIRED, 'Один шаблон вместо всех: ' . implode(', ', self::TEMPLATES));
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $email = trim((string) $input->getArgument('email'));
+
+        if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
+            $io->error('Нужен корректный email');
+            return Command::INVALID;
+        }
+
+        $only = $input->getOption('only');
+        $templates = $only !== null ? [$only] : self::TEMPLATES;
+
+        foreach ($templates as $template) {
+            if (!in_array($template, self::TEMPLATES, true)) {
+                $io->error(sprintf('Шаблон «%s» не поддержан. Доступны: %s', $template, implode(', ', self::TEMPLATES)));
+                return Command::INVALID;
+            }
+        }
+
+        $rows = [];
+        $failed = 0;
+
+        foreach ($templates as $template) {
+            $context = $this->contextFor($template);
+            if ($context === null) {
+                $rows[] = [$template, '— пропущен (нет данных в БД)'];
+                continue;
+            }
+
+            $ok = $this->notifier->send($email, '[ТЕСТ] ' . $template . ' — WEARBASE', $template, $context);
+            $rows[] = [$template, $ok ? '✅ отправлено' : '❌ ошибка (см. лог)'];
+            $failed += $ok ? 0 : 1;
+        }
+
+        $io->table(['Шаблон', 'Результат'], $rows);
+
+        if ($failed > 0) {
+            $io->error(sprintf('%d из %d писем не ушло — причина в логе (app.ERROR «Email notification failed»)', $failed, count($templates)));
+            return Command::FAILURE;
+        }
+
+        $io->success('Все письма приняты транспортом. Проверьте ящик ' . $email);
+
+        return Command::SUCCESS;
+    }
+
+    /** @return array<string,mixed>|null null — шаблон нельзя проверить без данных */
+    private function contextFor(string $template): ?array
+    {
+        return match ($template) {
+            'lead_welcome' => ['brandName' => 'Тестовый Бренд'],
+            'brand_access_granted' => [
+                'login' => 'test@example.com',
+                'tempPassword' => 'TempPass123',
+                'brandTitle' => 'Тестовый Бренд',
+            ],
+            'new_lead' => [
+                'leadEmail' => 'lead@example.com',
+                'source' => 'for-brands',
+                'brandName' => 'Тестовый Бренд',
+                'website' => 'example.com',
+            ],
+            'verify_email', 'reset_password' => ['token' => str_repeat('t', 32)],
+            'brand_claim_code' => ($brand = $this->em->getRepository(Brand::class)->findOneBy([], ['id' => 'ASC'])) !== null
+                ? ['brand' => $brand, 'code' => '123456']
+                : null,
+            default => null,
+        };
+    }
+}

--- a/tests/Command/MailTestCommandTest.php
+++ b/tests/Command/MailTestCommandTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Command;
+
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Bundle\FrameworkBundle\Test\MailerAssertionsTrait;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * Дымовой тест почты (app:mail:test): каждый шаблон должен отрендериться и уйти.
+ * Именно рендер `TemplatedEmail` ломался 19.07–26.07.2026, а `mailer:test` его не проверял.
+ */
+class MailTestCommandTest extends KernelTestCase
+{
+    use MailerAssertionsTrait;
+
+    private CommandTester $tester;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $this->tester = new CommandTester((new Application(self::$kernel))->find('app:mail:test'));
+    }
+
+    public function testSendsSingleTemplateWithRenderedBody(): void
+    {
+        $this->tester->execute(['email' => 'nevinny@example.com', '--only' => 'lead_welcome']);
+
+        $this->tester->assertCommandIsSuccessful();
+        $this->assertEmailCount(1);
+
+        $message = $this->getMailerMessage();
+        $this->assertSame('nevinny@example.com', $message->getTo()[0]->getAddress());
+        $this->assertStringContainsString('[ТЕСТ] lead_welcome', (string) $message->getSubject());
+        $this->assertNotSame('', (string) $message->getHtmlBody(), 'Тело должно быть отрендерено');
+        $this->assertStringContainsString('/register?brand=1', (string) $message->getHtmlBody());
+    }
+
+    public function testAllTemplatesRender(): void
+    {
+        $this->tester->execute(['email' => 'nevinny@example.com']);
+
+        $this->tester->assertCommandIsSuccessful();
+        foreach ($this->getMailerMessages() as $message) {
+            $this->assertNotSame('', (string) $message->getHtmlBody(), 'Пустое тело: ' . $message->getSubject());
+        }
+        $this->assertGreaterThanOrEqual(5, count($this->getMailerMessages()));
+    }
+
+    public function testUnknownTemplateRejected(): void
+    {
+        $this->tester->execute(['email' => 'nevinny@example.com', '--only' => 'nope']);
+
+        $this->assertSame(2, $this->tester->getStatusCode());
+        $this->assertEmailCount(0);
+    }
+}


### PR DESCRIPTION
## Зачем
Проверять почту через `mailer:test` бесполезно: он шлёт обычный `Email` с готовым текстом, twig-рендер ему не нужен. Ровно поэтому 19.07 диагноз получился неверным — `mailer:test` доходил до API и возвращал 401, а настоящие `TemplatedEmail` падали раньше на пустом теле, и это никто не видел.

## Что
`app:mail:test <email> [--only=шаблон]` — прогоняет через `EmailNotifier` (тот же путь, что приложение) шесть шаблонов с синтетическим контекстом: `lead_welcome`, `brand_access_granted`, `new_lead`, `verify_email`, `reset_password`, `brand_claim_code` (последний берёт первый бренд из БД, без него — «пропущен»). Итог — таблица «шаблон → отправлено/ошибка», ненулевой exit при провале.

Шаблоны, которым нужны реальные Order/Claim/Invite, не включены — у них свои сценарии.

## Тесты
Рендер тела непустой у всех шаблонов, `--only` работает, неизвестный шаблон → INVALID без отправки. Локально **326 OK**.