### PR TITLE
fix: ссылки в письмах из CLI вели на http://localhost

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -20,7 +20,9 @@ APP_SECRET=ci_dummy_secret
 ###< symfony/framework-bundle ###
 
 ###> symfony/routing ###
-DEFAULT_URI=http://localhost
+# Базовый URL для ссылок в письмах/уведомлениях из CLI и крона (в веб-запросе хост берётся из
+# запроса). ⚠️ На проде обязателен https://wearbase.ru — иначе ссылки в письмах ведут на localhost.
+DEFAULT_URI=https://wearbase.ru
 ###< symfony/routing ###
 
 ###> doctrine/doctrine-bundle ###

--- a/.env.test
+++ b/.env.test
@@ -22,3 +22,6 @@ QDRANT_COLLECTION='brand_chunks_test'
 SEARXNG_URL='http://127.0.0.1:1'
 TRAFILATURA_BIN='/bin/true'
 SCRAPE_EXCLUDED_DOMAINS=''
+
+# Ссылки в письмах должны быть абсолютными на прод-домен (тест это проверяет).
+DEFAULT_URI=https://wearbase.ru

--- a/tests/Command/MailTestCommandTest.php
+++ b/tests/Command/MailTestCommandTest.php
@@ -36,7 +36,12 @@ class MailTestCommandTest extends KernelTestCase
         $this->assertSame('nevinny@example.com', $message->getTo()[0]->getAddress());
         $this->assertStringContainsString('[ТЕСТ] lead_welcome', (string) $message->getSubject());
         $this->assertNotSame('', (string) $message->getHtmlBody(), 'Тело должно быть отрендерено');
-        $this->assertStringContainsString('/register?brand=1', (string) $message->getHtmlBody());
+        // Ссылки обязаны быть абсолютными на прод-домен: письма из CLI/крона рендерятся вне
+        // веб-запроса, хост берётся из DEFAULT_URI. При DEFAULT_URI=http://localhost (дефолт .env)
+        // лид получал письмо со ссылками в никуда — регрессия найдена 26.07.2026 в живом ящике.
+        $body = (string) $message->getHtmlBody();
+        $this->assertStringContainsString('https://wearbase.ru/register?brand=1', $body);
+        $this->assertStringNotContainsString('localhost', $body);
     }
 
     public function testAllTemplatesRender(): void


### PR DESCRIPTION
## Как нашлось
Открыл прод-письма в живом ящике и раскрыл клик-редирект RuSender: внутри `"userLink":"http://localhost/reset-password/tttt…"`. То есть кнопки в письмах, отправленных из CLI/крона, ведут в никуда.

## Причина
`config/packages/routing.yaml` берёт `default_uri: '%env(DEFAULT_URI)%'`, а `DEFAULT_URI=http://localhost` (дефолт `.env`), на проде в `.env.local` переопределения не было. В веб-запросе хост подставляется из самого запроса — поэтому письма, отправленные из контроллеров (регистрация, заказы), ссылались правильно, а всё из команд и крона (дайджест, пригласительное письмо, drip-уведомления) — на localhost.

## Фикс
- `.env.dist`: `DEFAULT_URI=https://wearbase.ru` с предупреждением, зачем это нужно.
- `.env.test`: тот же прод-домен, чтобы регрессию ловил тест.
- Тест: тело письма содержит `https://wearbase.ru/register?brand=1` и **не** содержит `localhost`.
- Прод `.env.local` правлю руками (не в репозитории), после чего перепроверяю письмо в ящике.

Локально **326 OK**.