### PR TITLE
fix(admin): записи с parent = NULL были не видны в админке

### DIFF
--- a/src/Command/FixNullParentCommand.php
+++ b/src/Command/FixNullParentCommand.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Command;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Nevinny\AdminCoreBundle\Entity\Trait\DefaultFields;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * Заменяет `parent = NULL` на `parent = 0` у сущностей на трейте {@see DefaultFields}.
+ *
+ * Зачем: листинг админки (`DefaultCrudController::createIndexQueryBuilder`) фильтрует
+ * `entity.parent = 0`, а NULL под равенство не попадает — записи есть в БД, но в админке
+ * невидимы. На проде так пряталось 3325 брендов из 3669.
+ *
+ * Идемпотентна: повторный запуск ничего не меняет. Новые записи держит
+ * {@see \App\EventListener\DefaultParentSubscriber}.
+ */
+#[AsCommand(
+    name: 'app:fix:null-parent',
+    description: 'parent = NULL → 0 (иначе записи не видны в админке)',
+)]
+class FixNullParentCommand extends Command
+{
+    public function __construct(private readonly EntityManagerInterface $em)
+    {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->addOption('dry-run', null, InputOption::VALUE_NONE, 'Только показать, что будет исправлено');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $dryRun = (bool) $input->getOption('dry-run');
+
+        $rows = [];
+        $total = 0;
+
+        foreach ($this->em->getMetadataFactory()->getAllMetadata() as $metadata) {
+            $class = $metadata->getName();
+
+            if (!$this->usesDefaultFields($class) || $metadata->hasAssociation('parent')) {
+                continue;
+            }
+
+            $affected = (int) $this->em->createQuery(
+                sprintf('SELECT COUNT(e.id) FROM %s e WHERE e.parent IS NULL', $class)
+            )->getSingleScalarResult();
+
+            if ($affected === 0) {
+                continue;
+            }
+
+            if (!$dryRun) {
+                $this->em->createQuery(
+                    sprintf('UPDATE %s e SET e.parent = 0 WHERE e.parent IS NULL', $class)
+                )->execute();
+            }
+
+            $rows[] = [$metadata->getTableName(), $affected];
+            $total += $affected;
+        }
+
+        if ($rows === []) {
+            $io->success('Записей с parent = NULL нет — исправлять нечего.');
+
+            return Command::SUCCESS;
+        }
+
+        $io->table(['Таблица', $dryRun ? 'Будет исправлено' : 'Исправлено'], $rows);
+        $io->success(sprintf('%s %d записей', $dryRun ? 'К исправлению:' : 'Исправлено:', $total));
+
+        if ($dryRun) {
+            $io->note('Это dry-run — запустите без --dry-run, чтобы применить.');
+        }
+
+        return Command::SUCCESS;
+    }
+
+    private function usesDefaultFields(string $class): bool
+    {
+        for ($c = $class; $c !== false; $c = get_parent_class($c)) {
+            if (in_array(DefaultFields::class, class_uses($c) ?: [], true)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/EventListener/DefaultParentSubscriber.php
+++ b/src/EventListener/DefaultParentSubscriber.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\EventListener;
+
+use Doctrine\Bundle\DoctrineBundle\Attribute\AsDoctrineListener;
+use Doctrine\ORM\Event\PrePersistEventArgs;
+use Doctrine\ORM\Events;
+use Nevinny\AdminCoreBundle\Entity\Trait\DefaultFields;
+
+/**
+ * Подставляет `parent = 0` новым сущностям, у которых поле не заполнено.
+ *
+ * Зачем: листинг EasyAdmin в `Nevinny\AdminCoreBundle\Controller\Admin\DefaultCrudController`
+ * без параметра `parent_id` добавляет условие `entity.parent = 0`, а `NULL` под равенство
+ * в SQL не попадает — запись физически есть, но в админке её не видно. Дефолт трейта
+ * {@see DefaultFields} при этом `null`, поэтому всё, что создаётся кодом (импорты,
+ * RAG-конвейер, LK), выпадало из админки.
+ *
+ * Разовая правка уже накопленных строк — `app:fix:null-parent`.
+ */
+#[AsDoctrineListener(event: Events::prePersist)]
+class DefaultParentSubscriber
+{
+    public function prePersist(PrePersistEventArgs $args): void
+    {
+        $entity = $args->getObject();
+
+        // Только сущности на трейте DefaultFields: у них parent — int. У сущностей со связью
+        // parent (Main, ProductCategory) сеттер ждёт объект, туда 0 подставлять нельзя.
+        if (!self::usesDefaultFields($entity::class)) {
+            return;
+        }
+
+        if ($entity->getParent() === null) {
+            $entity->setParent(0);
+        }
+    }
+
+    private static function usesDefaultFields(string $class): bool
+    {
+        for ($c = $class; $c !== false; $c = get_parent_class($c)) {
+            if (in_array(DefaultFields::class, class_uses($c) ?: [], true)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/tests/Command/FixNullParentCommandTest.php
+++ b/tests/Command/FixNullParentCommandTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Command;
+
+use App\Entity\BrandStyle;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * parent = NULL → 0 (app:fix:null-parent) + предохранитель на prePersist.
+ *
+ * Листинг админки (DefaultCrudController) фильтрует `entity.parent = 0`, поэтому строки
+ * с NULL в админке не видны: на проде так пряталось 3325 брендов из 3669.
+ */
+class FixNullParentCommandTest extends KernelTestCase
+{
+    private EntityManagerInterface $em;
+    private CommandTester $tester;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $this->em = self::getContainer()->get(EntityManagerInterface::class);
+        $this->em->beginTransaction();
+        $this->tester = new CommandTester((new Application(self::$kernel))->find('app:fix:null-parent'));
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->em->getConnection()->isTransactionActive()) {
+            $this->em->rollback();
+        }
+        parent::tearDown();
+    }
+
+    public function testNewEntityGetsZeroParentOnPersist(): void
+    {
+        $style = (new BrandStyle())->setTitle('Стиль ' . uniqid());
+        $style->setSlug('style-' . uniqid());
+        $this->em->persist($style);
+        $this->em->flush();
+
+        $this->assertSame(0, $style->getParent(), 'prePersist должен подставлять parent = 0');
+    }
+
+    public function testCommandFixesExistingNulls(): void
+    {
+        $style = $this->styleWithNullParent();
+
+        $this->tester->execute([]);
+
+        $this->tester->assertCommandIsSuccessful();
+        $this->em->refresh($style);
+        $this->assertSame(0, $style->getParent(), 'Команда должна заменить NULL на 0');
+    }
+
+    public function testDryRunChangesNothing(): void
+    {
+        $style = $this->styleWithNullParent();
+
+        $this->tester->execute(['--dry-run' => true]);
+
+        $this->tester->assertCommandIsSuccessful();
+        $this->assertStringContainsString('dry-run', $this->tester->getDisplay());
+        $this->em->refresh($style);
+        $this->assertNull($style->getParent(), 'dry-run не должен ничего менять');
+    }
+
+    /** Обходим prePersist-предохранитель, чтобы получить строку с NULL как в проде. */
+    private function styleWithNullParent(): BrandStyle
+    {
+        $style = (new BrandStyle())->setTitle('Стиль ' . uniqid());
+        $style->setSlug('style-' . uniqid());
+        $this->em->persist($style);
+        $this->em->flush();
+
+        $this->em->createQuery('UPDATE App\Entity\BrandStyle s SET s.parent = NULL WHERE s.id = :id')
+            ->setParameter('id', $style->getId())
+            ->execute();
+        $this->em->refresh($style);
+        $this->assertNull($style->getParent());
+
+        return $style;
+    }
+}


### PR DESCRIPTION
## Причина
`Nevinny\AdminCoreBundle\Controller\Admin\DefaultCrudController::createIndexQueryBuilder` при отсутствии `parent_id` в запросе добавляет `entity.parent = 0`. В SQL `NULL = 0` — не истина, поэтому строки с `parent IS NULL` физически есть, но в листингах админки невидимы. Дефолт трейта `DefaultFields` — именно `null`, а наш код (импорты, RAG-конвейер, ЛК) parent не заполняет.

## Масштаб на проде
| Таблица | Всего | `parent IS NULL` |
|---|---|---|
| `brand` | 3669 | **3325** |
| `brand_link` | 4810 | 4802 |
| `brand_style` | 29 | 12 |

То есть в админке было видно меньше 10% брендов.

## Что сделано
- **`app:fix:null-parent [--dry-run]`** — DQL-обновление `NULL → 0` по всем сущностям на трейте `DefaultFields` (Brand, Product, BrandLink, BrandStyle, BrandSize, BrandAudience, BrandTier, BrandImage, ProductImage). Идемпотентна, dry-run показывает таблицу с количеством.
- **`DefaultParentSubscriber`** (`prePersist`) — новым записям подставляет `parent = 0`, иначе проблема вернётся с первым же импортом. Сущности со **связью** `parent` (`Main`, `ProductCategory`) не трогает: там сеттер ждёт объект, а не int.
- Тесты: предохранитель ставит 0; команда исправляет существующие NULL; `--dry-run` ничего не меняет.

Локально **330 OK**.

## Правильное место для корневого фикса
Условие стоило бы починить в самом `admin-core`: `entity.parent = 0 OR entity.parent IS NULL` (или дефолт трейта `= 0`). Пакет отдельный (`nevinny/admin-core ^1.0.6`), релиз — за тобой; наш фикс работает независимо от версии бандла.