### PR TITLE
fix(admin): детект parent по метаданным — иначе Brand выпадал из фикса

### DIFF
--- a/src/Command/FixNullParentCommand.php
+++ b/src/Command/FixNullParentCommand.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace App\Command;
 
 use Doctrine\ORM\EntityManagerInterface;
-use Nevinny\AdminCoreBundle\Entity\Trait\DefaultFields;
+use Doctrine\ORM\Mapping\ClassMetadata;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -14,7 +14,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
 /**
- * Заменяет `parent = NULL` на `parent = 0` у сущностей на трейте {@see DefaultFields}.
+ * Заменяет `parent = NULL` на `parent = 0` у сущностей, где `parent` — скалярное int-поле.
  *
  * Зачем: листинг админки (`DefaultCrudController::createIndexQueryBuilder`) фильтрует
  * `entity.parent = 0`, а NULL под равенство не попадает — записи есть в БД, но в админке
@@ -22,6 +22,10 @@ use Symfony\Component\Console\Style\SymfonyStyle;
  *
  * Идемпотентна: повторный запуск ничего не меняет. Новые записи держит
  * {@see \App\EventListener\DefaultParentSubscriber}.
+ *
+ * ⚠️ Детект — по метаданным Doctrine, а НЕ по трейту `DefaultFields`: `Brand` объявляет `parent`
+ * самостоятельно (трейт только импортирован, но не подключён), и проверка по трейту пропускала
+ * как раз самую большую таблицу.
  */
 #[AsCommand(
     name: 'app:fix:null-parent',
@@ -50,7 +54,7 @@ class FixNullParentCommand extends Command
         foreach ($this->em->getMetadataFactory()->getAllMetadata() as $metadata) {
             $class = $metadata->getName();
 
-            if (!$this->usesDefaultFields($class) || $metadata->hasAssociation('parent')) {
+            if (!$this->hasScalarParent($metadata)) {
                 continue;
             }
 
@@ -88,14 +92,11 @@ class FixNullParentCommand extends Command
         return Command::SUCCESS;
     }
 
-    private function usesDefaultFields(string $class): bool
+    /** Скалярное int-поле `parent`; сущности со СВЯЗЬЮ parent (Main, ProductCategory) — не наш случай. */
+    public static function hasScalarParent(ClassMetadata $metadata): bool
     {
-        for ($c = $class; $c !== false; $c = get_parent_class($c)) {
-            if (in_array(DefaultFields::class, class_uses($c) ?: [], true)) {
-                return true;
-            }
-        }
-
-        return false;
+        return !$metadata->hasAssociation('parent')
+            && $metadata->hasField('parent')
+            && $metadata->getTypeOfField('parent') === 'integer';
     }
 }

--- a/src/EventListener/DefaultParentSubscriber.php
+++ b/src/EventListener/DefaultParentSubscriber.php
@@ -4,19 +4,18 @@ declare(strict_types=1);
 
 namespace App\EventListener;
 
+use App\Command\FixNullParentCommand;
 use Doctrine\Bundle\DoctrineBundle\Attribute\AsDoctrineListener;
 use Doctrine\ORM\Event\PrePersistEventArgs;
 use Doctrine\ORM\Events;
-use Nevinny\AdminCoreBundle\Entity\Trait\DefaultFields;
 
 /**
  * Подставляет `parent = 0` новым сущностям, у которых поле не заполнено.
  *
  * Зачем: листинг EasyAdmin в `Nevinny\AdminCoreBundle\Controller\Admin\DefaultCrudController`
  * без параметра `parent_id` добавляет условие `entity.parent = 0`, а `NULL` под равенство
- * в SQL не попадает — запись физически есть, но в админке её не видно. Дефолт трейта
- * {@see DefaultFields} при этом `null`, поэтому всё, что создаётся кодом (импорты,
- * RAG-конвейер, LK), выпадало из админки.
+ * в SQL не попадает — запись физически есть, но в админке её не видно. Дефолт поля при этом
+ * `null`, поэтому всё, что создаётся кодом (импорты, RAG-конвейер, ЛК), выпадало из админки.
  *
  * Разовая правка уже накопленных строк — `app:fix:null-parent`.
  */
@@ -27,25 +26,15 @@ class DefaultParentSubscriber
     {
         $entity = $args->getObject();
 
-        // Только сущности на трейте DefaultFields: у них parent — int. У сущностей со связью
-        // parent (Main, ProductCategory) сеттер ждёт объект, туда 0 подставлять нельзя.
-        if (!self::usesDefaultFields($entity::class)) {
+        // Только скалярный int-parent (Brand объявляет его сам, вне трейта DefaultFields).
+        // У сущностей со СВЯЗЬЮ parent сеттер ждёт объект — туда 0 подставлять нельзя.
+        $metadata = $args->getObjectManager()->getClassMetadata($entity::class);
+        if (!FixNullParentCommand::hasScalarParent($metadata)) {
             return;
         }
 
         if ($entity->getParent() === null) {
             $entity->setParent(0);
         }
-    }
-
-    private static function usesDefaultFields(string $class): bool
-    {
-        for ($c = $class; $c !== false; $c = get_parent_class($c)) {
-            if (in_array(DefaultFields::class, class_uses($c) ?: [], true)) {
-                return true;
-            }
-        }
-
-        return false;
     }
 }

--- a/tests/Command/FixNullParentCommandTest.php
+++ b/tests/Command/FixNullParentCommandTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tests\Command;
 
+use App\Entity\Brand;
 use App\Entity\BrandStyle;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
@@ -85,5 +86,33 @@ class FixNullParentCommandTest extends KernelTestCase
         $this->assertNull($style->getParent());
 
         return $style;
+    }
+
+    /**
+     * Brand объявляет `parent` сам, трейт DefaultFields в нём НЕ подключён (только импортирован).
+     * Детект обязан идти по метаданным Doctrine — иначе самая большая таблица (3325 строк на
+     * проде) остаётся не исправленной, как и было в первой версии фикса.
+     */
+    public function testBrandIsCoveredDespiteNotUsingTrait(): void
+    {
+        $brand = (new Brand())->setTitle('Бренд ' . uniqid());
+        $brand->setSlug('brand-parent-' . uniqid());
+        $this->em->persist($brand);
+        $this->em->flush();
+
+        $this->assertSame(0, $brand->getParent(), 'prePersist должен покрывать и Brand');
+
+        $this->em->createQuery('UPDATE App\Entity\Brand b SET b.parent = NULL WHERE b.id = :id')
+            ->setParameter('id', $brand->getId())
+            ->execute();
+        $this->em->refresh($brand);
+        $this->assertNull($brand->getParent());
+
+        $this->tester->execute([]);
+
+        $this->tester->assertCommandIsSuccessful();
+        $this->assertStringContainsString('brand', $this->tester->getDisplay());
+        $this->em->refresh($brand);
+        $this->assertSame(0, $brand->getParent());
     }
 }


### PR DESCRIPTION
Догоняет #50: dry-run на проде показал только `brand_link` и `brand_style`, а `brand` — нет, хотя сырой SQL насчитал там 3325 строк с `parent IS NULL`.

Причина: `Brand` **не подключает** трейт `DefaultFields` — импорт в файле есть (висячий), но `use DefaultFields` в теле класса нет; поле `parent` объявлено в самой сущности. Детект по трейту его не видел, то есть первая версия фикса не трогала как раз самую большую таблицу.

Теперь детект по метаданным Doctrine: `hasField('parent')` + тип `integer` + отсутствие одноимённой ассоциации (`Main`, `ProductCategory` со связью-parent по-прежнему не трогаем — там сеттер ждёт объект). Тот же критерий использует `prePersist`-подписчик.

Dry-run на dev после правки: `brand` 6837, `brand_link` 8387, `brand_style` 12, `product` 8. Тест на Brand добавлен (объявление вне трейта + исправление NULL). Локально **331 OK**.