### PR TITLE
fix(deploy): удалённые файлы больше не остаются на проде навсегда

### DIFF
--- a/.claude/skills/deploy/SKILL.md
+++ b/.claude/skills/deploy/SKILL.md
@@ -13,7 +13,17 @@ model: sonnet
 2. Ветка main, локальные коммиты запушены (`git push`).
 3. `php bin/console doctrine:migrations:status --no-debug` локально — сколько миграций поедет; если > 0, перечисли их пользователю в отчёте.
 
-**Деплой:** полный rsync из корня проекта (НЕ отдельные файлы — см. «Грабли деплоя» в tasktracker), затем серверная часть из production.md. ⚠️ На проде `cache:clear` ТОЛЬКО с `-d memory_limit=512M` (дефолт 128M — падает). ⚠️ На macOS нет команды `timeout` — не используй её в обвязке.
+**Деплой:** полный rsync из корня проекта (НЕ отдельные файлы — см. «Грабли деплоя» в tasktracker), затем серверная часть из production.md.
+
+⚠️ **Удалённые файлы основной rsync не убирает** (он без `--delete`, чтобы не снести прод-only данные) — на 26.07.2026 на проде так жили бутстраповый `templates/base.html.twig`, `showv2/showv3` и другой мёртвый код, который Symfony продолжает автозагружать. После основного rsync прогони второй проход ТОЛЬКО по каталогам чистого кода:
+
+```bash
+for DIR in src templates migrations translations; do
+  rsync -az --delete --exclude .DS_Store ./$DIR/ regru:/var/www/u3042786/data/wearbase.ru/$DIR/
+done
+```
+
+`public_html` (сгенерированные ассеты и загруженные картинки), `bin`, `var`, `config/secrets` в этот проход **не включать**. Перед первым применением на новом каталоге — `rsync -aznv --delete …` и глазами прочитать список `deleting`. ⚠️ На проде `cache:clear` ТОЛЬКО с `-d memory_limit=512M` (дефолт 128M — падает). ⚠️ На macOS нет команды `timeout` — не используй её в обвязке.
 
 **Smoke-тест (после):**
 1. `curl -s -o /dev/null -w '%{http_code}' https://wearbase.ru/ru/` → 200; `/ru/brands/` → 200; `/admin` → 302/200.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,25 @@ jobs:
             -e "ssh -i ~/.ssh/deploy_key -p ${P} -o UserKnownHostsFile=~/.ssh/known_hosts" \
             ./ "${U}@${H}:${D}/"
 
+      - name: Prune deleted code files
+        # Основной rsync идёт без --delete, поэтому удалённые в репозитории файлы жили на
+        # проде вечно: 26.07.2026 там нашлись бутстраповый templates/base.html.twig,
+        # showv2/showv3 и снесённый в этом же релизе слушатель — мёртвый код, который
+        # Symfony продолжает автозагружать. Второй проход с --delete идёт ТОЛЬКО по
+        # каталогам чистого кода: public_html (сгенерированные ассеты, загруженные
+        # картинки), bin, var и config/secrets сюда намеренно не входят.
+        env:
+          H: ${{ secrets.DEPLOY_HOST }}
+          U: ${{ secrets.DEPLOY_USER }}
+          P: ${{ secrets.DEPLOY_PORT }}
+          D: ${{ secrets.DEPLOY_PATH }}
+        run: |
+          for DIR in src templates migrations translations; do
+            rsync -az --delete --exclude .DS_Store \
+              -e "ssh -i ~/.ssh/deploy_key -p ${P} -o UserKnownHostsFile=~/.ssh/known_hosts" \
+              "./$DIR/" "${U}@${H}:${D}/$DIR/"
+          done
+
       - name: Migrate + clear cache
         # cache:clear на проде ТОЛЬКО с -d memory_limit=512M (дефолт 128M падает).
         env:


### PR DESCRIPTION
## Что вскрылось
Удалил в прошлом PR класс — а на проде он остался. Основной rsync намеренно идёт **без `--delete`** (иначе снесёт `var`, `.env.local`, загруженные картинки), поэтому всё, что когда-либо удалялось из репозитория, продолжает лежать на сервере и автозагружаться Symfony.

Дry-run показал 17 таких путей, в том числе:
- `templates/base.html.twig` и весь `templates/components/*` — бутстрап, удалённый 12.06 (CLAUDE.md прямо говорит «не воскрешать»);
- `templates/tailwind/brand/showv2.html.twig` и `showv3.html.twig` — старые версии карточки бренда;
- `templates/local-brands/index.html.twig`, `templates/sitemap/sitemap.xml.twig`, `templates/tailwind/index.html.twig`, `src/Validator/`.

Проверил ссылки: в текущем репозитории ни один из путей не используется (две находки по `base.html.twig` — комментарии). На проде файлы забэкаплены в `var/backup/stale-code-20260727.tar.gz` и удалены, кэш очищен, smoke по шести URL — 200.

## Что в PR
Второй проход `rsync --delete` по каталогам **чистого кода**: `src`, `templates`, `migrations`, `translations`. Намеренно НЕ включены `public_html` (там сгенерированные ассеты `bundles/easyadmin/*` и загруженные картинки), `bin` (ad-hoc скрипты на сервере), `var`, `config/secrets`.

То же самое добавлено в ручной `/deploy`-скилл с требованием сперва прогнать `rsync -aznv --delete` и прочитать список `deleting` глазами.