### PR TITLE
ci: авторевью каждого PR (claude-code-action) + пинг в TG

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -80,6 +80,7 @@ jobs:
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_NUM: ${{ github.event.pull_request.number }}
           PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
           OUTCOME: ${{ steps.review.outcome }}
         run: |
           case "$OUTCOME" in
@@ -88,8 +89,8 @@ jobs:
             *)        ICON="⚠️"; STATE="ревью упало ($OUTCOME)" ;;
           esac
           esc() { printf '%s' "$1" | sed 's/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g'; }
-          TEXT=$(printf '%s <b>PR #%s</b> — %s\n%s\n%s' \
-            "$ICON" "$PR_NUM" "$STATE" "$(esc "$PR_TITLE")" "$PR_URL")
+          TEXT=$(printf '%s <b>PR #%s</b> — %s\n%s\nАвтор: %s\n%s' \
+            "$ICON" "$PR_NUM" "$STATE" "$(esc "$PR_TITLE")" "$(esc "$PR_AUTHOR")" "$PR_URL")
           curl -sS -X POST "https://api.telegram.org/bot${TG_TOKEN}/sendMessage" \
             --data-urlencode "chat_id=${TG_CHAT}" \
             --data-urlencode "parse_mode=HTML" \

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,97 @@
+name: Claude review
+
+# Авторевью каждого PR. Комментарий с находками — в сам PR, пинг со ссылкой — в
+# TG-группу Wearbase_admin. Ревью НЕ блокирует мерж (не required check) — это
+# советник, решение о мерже остаётся за человеком.
+#
+# Секреты: CLAUDE_CODE_OAUTH_TOKEN (claude setup-token, Pro/Max),
+# TELEGRAM_BOT_TOKEN + ADMIN_TELEGRAM_CHAT_ID (тот же бот, что шлёт дайджесты).
+# Репозиторий публичный: PR из форков секретов не получают — джоба там пропускается.
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    name: Claude review
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    env:
+      CLAUDE_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+      TG_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+      TG_CHAT: ${{ secrets.ADMIN_TELEGRAM_CHAT_ID }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Claude review
+        id: review
+        # Пропускаем, если токен ещё не заведён, — иначе каждый PR краснел бы.
+        if: env.CLAUDE_TOKEN != ''
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          track_progress: true
+          claude_args: |
+            --max-turns 15
+          prompt: |
+            Отревьюй диff этого pull request. Отвечай по-русски, комментарием в PR.
+
+            Читай CLAUDE.md в корне — правила проекта обязательны к проверке.
+            Обрати особое внимание на нарушения, характерные для этого репозитория:
+
+            - **Soft-delete only**: физический DELETE по действию пользователя запрещён
+              (только status=deleted / deleted_at). Выборки обязаны фильтровать удалённое.
+            - **Два фаервола и две сущности User**: `/admin` → AdminCore\Entity\User,
+              остальное → App\Entity\User. Смешение — критично.
+            - **Миграции**: только `doctrine:migrations:diff`, идемпотентные
+              (CREATE TABLE IF NOT EXISTS / INSERT IGNORE), никакого schema:update.
+              FK на `country.id` — обязательно INT UNSIGNED (иначе MySQL 3780).
+            - **Деньги**: цены хранятся в рублях, конвертация только на лету через
+              CurrencyConverter / фильтр `|price`; сконвертированное в БД не пишем.
+            - **Шаблоны**: единый Tailwind-стек (base.html.twig — публичные страницы,
+              app.html.twig — ЛК/авторизация). Bootstrap воскрешать нельзя.
+              Флеш-сообщения рендерятся глобально, per-page циклов не добавлять.
+            - **Секреты**: ключи/токены/chat_id не должны попадать в код и в YAML —
+              репозиторий публичный.
+            - **Karpathy-правила**: лишние абстракции, спекулятивная «гибкость» и
+              правки, не относящиеся к задаче PR, — это находки.
+
+            Формат: список находок, каждая с приоритетом 🔴 (блокер) / 🟠 (важное) /
+            🟡 (мелочь) и ссылкой `файл:строка`. Если находок нет — так и напиши одной
+            строкой. Не хвали, не пересказывай диff, не предлагай рефакторинг соседнего
+            кода. Ничего не коммить и не пушить — только ревью.
+
+      - name: Пинг в Telegram
+        if: always() && env.TG_TOKEN != '' && env.TG_CHAT != ''
+        env:
+          # Заголовок PR — недоверенный ввод: только через env, никогда не подставлять
+          # ${{ ... }} внутрь shell-строки (script injection).
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_NUM: ${{ github.event.pull_request.number }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          OUTCOME: ${{ steps.review.outcome }}
+        run: |
+          case "$OUTCOME" in
+            success)  ICON="🔍"; STATE="ревью готово" ;;
+            skipped)  ICON="⏭"; STATE="ревью пропущено (нет CLAUDE_CODE_OAUTH_TOKEN)" ;;
+            *)        ICON="⚠️"; STATE="ревью упало ($OUTCOME)" ;;
+          esac
+          esc() { printf '%s' "$1" | sed 's/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g'; }
+          TEXT=$(printf '%s <b>PR #%s</b> — %s\n%s\n%s' \
+            "$ICON" "$PR_NUM" "$STATE" "$(esc "$PR_TITLE")" "$PR_URL")
+          curl -sS -X POST "https://api.telegram.org/bot${TG_TOKEN}/sendMessage" \
+            --data-urlencode "chat_id=${TG_CHAT}" \
+            --data-urlencode "parse_mode=HTML" \
+            --data-urlencode "disable_web_page_preview=true" \
+            --data-urlencode "text=${TEXT}" >/dev/null


### PR DESCRIPTION
Новый workflow `.github/workflows/claude-review.yml`: на каждый `pull_request` (opened/synchronize) Claude ревьюит диff и пишет находки комментарием в PR, в TG-группу Wearbase_admin уходит пинг со ссылкой.

- Ревью **не блокирует мерж** — не required check, решение за человеком.
- Промпт заточен под CLAUDE.md: soft-delete, два фаервола/две сущности User, идемпотентные миграции и INT UNSIGNED FK на `country.id`, цены только в рублях, единый Tailwind-стек, секреты в публичном репо.
- PR из форков пропускаются (секретов им GitHub не отдаёт).
- Заголовок PR подставляется через env, а не в shell-строку (script injection).

⚠️ Пока в секретах нет `CLAUDE_CODE_OAUTH_TOKEN` — шаг ревью скипается, в TG придёт «ревью пропущено». Этот PR как раз проверит TG-путь.

🤖 Generated with [Claude Code](https://claude.com/claude-code)