### PR TITLE
fix(admin): пароль администратора нельзя было сменить, форма показывала хеш

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -300,3 +300,11 @@ services:
         arguments:
             $projectDir: '%kernel.project_dir%'
             $fontPath: '%kernel.project_dir%/config/social/fonts/NotoSans.ttf'
+
+    # Вендорный CRUD админов (nevinny/admin-core) не имеет configureFields: EasyAdmin
+    # генерил поля из метаданных и выводил колонку `password` текстовым полем с bcrypt-хешем,
+    # а сохранение писало введённое без хеширования. Снимаем автоконфигурацию, чтобы
+    # EasyAdmin его не видел — маршруты /admin/user/* обслуживает App\Controller\Admin\UserCrudController.
+    Nevinny\AdminCoreBundle\Controller\Admin\UserCrudController:
+        autoconfigure: false
+        autowire: false

--- a/src/Controller/Admin/DashboardController.php
+++ b/src/Controller/Admin/DashboardController.php
@@ -126,6 +126,9 @@ class DashboardController extends AbstractDashboardController
         yield MenuItem::linkToCrud('Учёт AI-запросов', 'fas fa-receipt', AiUsageLog::class);
 
         yield MenuItem::section('Пользователи');
-        yield MenuItem::linkToCrud('Users', 'fas fa-users', User::class);
+        // setController обязателен: для этой сущности есть ещё вендорный CRUD
+        // (nevinny/admin-core) без configureFields, который показывал хеш пароля.
+        yield MenuItem::linkToCrud('Администраторы', 'fas fa-users', User::class)
+            ->setController(UserCrudController::class);
     }
 }

--- a/src/Controller/Admin/UserCrudController.php
+++ b/src/Controller/Admin/UserCrudController.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller\Admin;
+
+use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
+use EasyCorp\Bundle\EasyAdminBundle\Config\KeyValueStore;
+use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
+use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
+use EasyCorp\Bundle\EasyAdminBundle\Field\BooleanField;
+use EasyCorp\Bundle\EasyAdminBundle\Field\EmailField;
+use EasyCorp\Bundle\EasyAdminBundle\Field\IdField;
+use EasyCorp\Bundle\EasyAdminBundle\Field\TextareaField;
+use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
+use Nevinny\AdminCoreBundle\Entity\User;
+use Symfony\Component\Form\Extension\Core\Type\PasswordType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+/**
+ * Администраторы (firewall `admin`, сущность из nevinny/admin-core).
+ *
+ * Перекрывает вендорный {@see \Nevinny\AdminCoreBundle\Controller\Admin\UserCrudController},
+ * у которого нет configureFields(): EasyAdmin генерил поля из метаданных Doctrine и выводил
+ * колонку `password` обычным текстовым полем — в форме редактирования стоял bcrypt-хеш, а
+ * сохранение писало введённое значение в БД КАК ЕСТЬ, без хеширования. То есть сменить
+ * пароль через админку было нельзя, а попытка это сделать ломала вход пользователю
+ * (провайдер сравнивает bcrypt-хеш с тем, что лежит в колонке).
+ *
+ * Здесь пароль — write-only поле: хеш не показывается никогда, пустое поле при
+ * редактировании означает «не менять», непустое хешируется в addPasswordHasher().
+ * Тот же приём, что для секретов в {@see SocialChannelCrudController}.
+ *
+ * Контроллер привязан к пункту меню явно (DashboardController), иначе EasyAdmin
+ * резолвит сущность на вендорный CRUD.
+ */
+class UserCrudController extends AbstractCrudController
+{
+    public function __construct(private readonly UserPasswordHasherInterface $hasher)
+    {
+    }
+
+    public static function getEntityFqcn(): string
+    {
+        return User::class;
+    }
+
+    public function configureCrud(Crud $crud): Crud
+    {
+        return $crud
+            ->setEntityLabelInSingular('Администратор')
+            ->setEntityLabelInPlural('Администраторы')
+            ->setDefaultSort(['id' => 'ASC']);
+    }
+
+    public function configureFields(string $pageName): iterable
+    {
+        yield IdField::new('id')->hideOnForm();
+        yield EmailField::new('email', 'Email');
+        yield TextField::new('password', 'Новый пароль')
+            ->onlyOnForms()
+            ->setRequired($pageName === Crud::PAGE_NEW)
+            ->setFormType(PasswordType::class)
+            ->setFormTypeOptions([
+                'mapped'   => false,
+                'required' => $pageName === Crud::PAGE_NEW,
+                'attr'     => ['autocomplete' => 'new-password'],
+            ])
+            ->setHelp($pageName === Crud::PAGE_NEW
+                ? 'Задайте пароль — он будет сохранён в виде хеша.'
+                : 'Пусто — пароль не меняется. Сохранённый хеш не показывается.');
+        yield BooleanField::new('isVerified', 'Подтверждён');
+        yield TextField::new('firstName', 'Имя');
+        yield TextField::new('lastName', 'Фамилия');
+        yield TextField::new('phone', 'Телефон');
+        yield TextareaField::new('address', 'Адрес')->hideOnIndex();
+    }
+
+    public function createNewFormBuilder(EntityDto $entityDto, KeyValueStore $formOptions, AdminContext $context): FormBuilderInterface
+    {
+        return $this->addPasswordHasher(parent::createNewFormBuilder($entityDto, $formOptions, $context));
+    }
+
+    public function createEditFormBuilder(EntityDto $entityDto, KeyValueStore $formOptions, AdminContext $context): FormBuilderInterface
+    {
+        return $this->addPasswordHasher(parent::createEditFormBuilder($entityDto, $formOptions, $context));
+    }
+
+    /**
+     * Поле unmapped — Doctrine само его не запишет, хеш кладёт только этот листенер
+     * и только когда поле заполнили. Пустая строка = пароль остаётся прежним.
+     */
+    private function addPasswordHasher(FormBuilderInterface $builder): FormBuilderInterface
+    {
+        return $builder->addEventListener(FormEvents::POST_SUBMIT, function (FormEvent $event): void {
+            $plain = $event->getForm()->get('password')->getData();
+            if (!is_string($plain) || trim($plain) === '') {
+                return;
+            }
+
+            $user = $event->getData();
+            if ($user instanceof User) {
+                $user->setPassword($this->hasher->hashPassword($user, trim($plain)));
+            }
+        });
+    }
+}


### PR DESCRIPTION
## Проблема

Вендорный `UserCrudController` (nevinny/admin-core) не имеет `configureFields()`, поэтому EasyAdmin генерил форму из метаданных Doctrine: колонка `password` выводилась **обычным текстовым инпутом с bcrypt-хешем внутри**, помеченным как обязательный.

Последствия были хуже, чем «нельзя сменить пароль»: введённое в это поле значение записывалось в БД **как есть, без хеширования** → вход пользователю ломался полностью (провайдер сравнивает bcrypt-хеш с содержимым колонки).

## Решение

- Свой `src/Controller/Admin/UserCrudController.php`: пароль — write-only поле (`PasswordType`, unmapped). Хеш не показывается; пусто при редактировании = не менять; непусто → хешируется на `POST_SUBMIT`. На создании поле обязательное.
- Вендорный CRUD снят с автоконфигурации (`config/services.yaml`). Без этого pretty URLs падают на конфликте маршрута `admin_user_index`, а старый URL `/admin/user/{id}/edit` продолжал бы отдавать дырявую форму в обход меню.
- Пункт меню привязан к контроллеру явно (`setController`), иначе EasyAdmin резолвит сущность на вендорный CRUD.

## Проверка

Вручную в браузере на локальной админке:

| Сценарий | Результат |
|---|---|
| Форма edit | Поле «Новый пароль» пустое, хеша нет |
| Сохранение с пустым паролем | Хеш в БД не изменился |
| Смена пароля через форму | Валидный bcrypt, новый пароль подходит, старый — нет |
| Форма создания | Пароль помечен обязательным |

PHPUnit: 380/380 зелёные.

## Осталось за рамками

В форме админа нет поля **Roles** — назначить/снять `ROLE_ADMIN` через UI по-прежнему нельзя, только CLI (`admin:user:promote`). Тот же пробел вендорного CRUD, отдельной задачей.

🤖 Generated with [Claude Code](https://claude.com/claude-code)