### PR TITLE
chore: игнорировать загруженные фото гардероба

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,8 @@
 /var/
 /public_html/images/brands
 /public_html/images/logos
+/public_html/images/wardrobe
+/public_html/images/wardrobe_drafts
 ###< symfony/framework-bundle ###
 
 # Секреты (Google OAuth/GSC service-account и пр.) — только локально


### PR DESCRIPTION
Каталоги `/public_html/images/wardrobe` и `wardrobe_drafts` не были в `.gitignore`, в отличие от `brands`/`logos`/`social`. Это пользовательские фото личных вещей — при работе с гардеробом они попадают в рабочую копию как untracked и могут уехать в репозиторий одним `git add -A`.

Всплыло при переносе гардероба на прод (PR #65).