### PR TITLE
Гардероб: полная форма и несколько фото при добавлении

### DIFF
--- a/src/Controller/Account/WardrobeController.php
+++ b/src/Controller/Account/WardrobeController.php
@@ -289,10 +289,17 @@ class WardrobeController extends AbstractController
                 $em->flush();
             }
 
+            // Вещь на этот момент уже сохранена, поэтому падение загрузчика нельзя пускать
+            // в 500: пользователь увидел бы ошибку и решил, что не сохранилось ничего.
+            // Ловим так же, как штатный эндпоинт photos_upload.
             if ($galleryPhotos !== []) {
-                $this->photoManager->upload($item, $galleryPhotos, WardrobeItemPhoto::TYPE_PRODUCT);
-                $this->wardrobeManager->refreshCompletionStatus($item);
-                $em->flush();
+                try {
+                    $this->photoManager->upload($item, $galleryPhotos, WardrobeItemPhoto::TYPE_PRODUCT);
+                    $this->wardrobeManager->refreshCompletionStatus($item);
+                    $em->flush();
+                } catch (\InvalidArgumentException $exception) {
+                    $this->addFlash('error', 'Вещь сохранена, но фотографии не загрузились: ' . $exception->getMessage());
+                }
             }
 
             $this->addFlash('success', 'Вещь добавлена');
@@ -307,7 +314,6 @@ class WardrobeController extends AbstractController
             'item'          => $item,
             'currentMember' => $currentMember,
             'isOwnWardrobe' => $currentMember->getId() === $user->getId(),
-            'fullMode'      => true,
         ]);
     }
 
@@ -502,11 +508,17 @@ class WardrobeController extends AbstractController
                 // (старое фото не теряем физически, но перестаёт быть обложкой).
                 $this->photoManager->reconcileAfterLegacyReplace($item, $previousPhoto);
             }
+            // Правки уже во flush выше — ошибка загрузчика не должна их «отменять» в глазах
+            // пользователя (см. тот же приём в new() и photos_upload).
             $galleryPhotos = $form->get('galleryPhotos')->getData() ?? [];
             if ($galleryPhotos !== []) {
-                $this->photoManager->upload($item, $galleryPhotos, WardrobeItemPhoto::TYPE_PRODUCT);
-                $this->wardrobeManager->refreshCompletionStatus($item);
-                $em->flush();
+                try {
+                    $this->photoManager->upload($item, $galleryPhotos, WardrobeItemPhoto::TYPE_PRODUCT);
+                    $this->wardrobeManager->refreshCompletionStatus($item);
+                    $em->flush();
+                } catch (\InvalidArgumentException $exception) {
+                    $this->addFlash('error', 'Изменения сохранены, но фотографии не загрузились: ' . $exception->getMessage());
+                }
             }
             $this->addFlash('success', 'Изменения сохранены');
             return $this->redirectToRoute(
@@ -520,7 +532,6 @@ class WardrobeController extends AbstractController
             'item'          => $item,
             'currentMember' => $currentMember,
             'isOwnWardrobe' => $currentMember->getId() === $user->getId(),
-            'fullMode'      => true,
         ]);
     }
 

--- a/src/Controller/Account/WardrobeController.php
+++ b/src/Controller/Account/WardrobeController.php
@@ -245,12 +245,13 @@ class WardrobeController extends AbstractController
         $currentMember = $this->familyService->resolveMember($user, $this->memberParam($request));
 
         $item = new WardrobeItem();
-        $form = $this->createForm(WardrobeItemFormType::class, $item, ['full' => false]);
+        $form = $this->createForm(WardrobeItemFormType::class, $item);
         $form->handleRequest($request);
         $remotePhotoUrl = $form->get('remotePhotoUrl')->getData();
+        $galleryPhotos = $form->get('galleryPhotos')->getData() ?? [];
 
         if ($form->isSubmitted() && $form->isValid()) {
-            if ($item->getPhotoFile() === null) {
+            if ($item->getPhotoFile() === null && $galleryPhotos === []) {
                 $this->remotePhotoFetcher->attachWildberriesPhoto($item, $remotePhotoUrl);
             }
             $item->setUser($currentMember);
@@ -288,6 +289,12 @@ class WardrobeController extends AbstractController
                 $em->flush();
             }
 
+            if ($galleryPhotos !== []) {
+                $this->photoManager->upload($item, $galleryPhotos, WardrobeItemPhoto::TYPE_PRODUCT);
+                $this->wardrobeManager->refreshCompletionStatus($item);
+                $em->flush();
+            }
+
             $this->addFlash('success', 'Вещь добавлена');
             if ($request->request->has('save_and_add')) {
                 return $this->redirectToRoute('account_wardrobe_new', $this->memberQuery($user, $currentMember));
@@ -300,7 +307,7 @@ class WardrobeController extends AbstractController
             'item'          => $item,
             'currentMember' => $currentMember,
             'isOwnWardrobe' => $currentMember->getId() === $user->getId(),
-            'fullMode'      => false,
+            'fullMode'      => true,
         ]);
     }
 
@@ -494,6 +501,12 @@ class WardrobeController extends AbstractController
                 // Vich уже сохранил новый файл и переписал item.photo — согласуем галерею
                 // (старое фото не теряем физически, но перестаёт быть обложкой).
                 $this->photoManager->reconcileAfterLegacyReplace($item, $previousPhoto);
+            }
+            $galleryPhotos = $form->get('galleryPhotos')->getData() ?? [];
+            if ($galleryPhotos !== []) {
+                $this->photoManager->upload($item, $galleryPhotos, WardrobeItemPhoto::TYPE_PRODUCT);
+                $this->wardrobeManager->refreshCompletionStatus($item);
+                $em->flush();
             }
             $this->addFlash('success', 'Изменения сохранены');
             return $this->redirectToRoute(

--- a/src/Form/Account/WardrobeItemFormType.php
+++ b/src/Form/Account/WardrobeItemFormType.php
@@ -12,6 +12,7 @@ use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\DateType;
+use Symfony\Component\Form\Extension\Core\Type\FileType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\Extension\Core\Type\NumberType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
@@ -19,6 +20,9 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\Extension\Core\Type\UrlType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraints\All;
+use Symfony\Component\Validator\Constraints\Count;
+use Symfony\Component\Validator\Constraints\File;
 use Symfony\Component\Validator\Constraints\GreaterThanOrEqual;
 use Symfony\Component\Validator\Constraints\Length;
 use Vich\UploaderBundle\Form\Type\VichImageType;
@@ -37,6 +41,22 @@ class WardrobeItemFormType extends AbstractType
                 // галерею (WardrobePhotoManager::softDelete), там soft-delete.
                 'allow_delete' => false,
                 'download_uri' => false,
+            ])
+            ->add('galleryPhotos', FileType::class, [
+                'label' => 'Дополнительные фотографии',
+                'mapped' => false,
+                'multiple' => true,
+                'required' => false,
+                'constraints' => [
+                    new Count(max: 8, maxMessage: 'Можно загрузить не больше 8 фотографий.'),
+                    new All([
+                        new File(
+                            maxSize: '10M',
+                            mimeTypes: ['image/jpeg', 'image/png', 'image/webp'],
+                            mimeTypesMessage: 'Разрешены только JPG, PNG и WebP.',
+                        ),
+                    ]),
+                ],
             ])
             ->add('productUrl', UrlType::class, [
                 'label' => 'Ссылка на товар',

--- a/src/Form/Account/WardrobeItemFormType.php
+++ b/src/Form/Account/WardrobeItemFormType.php
@@ -95,10 +95,6 @@ class WardrobeItemFormType extends AbstractType
                 ],
             ]);
 
-        if (!$options['full']) {
-            return;
-        }
-
         $builder
             ->add('name', TextType::class, [
                 'label' => 'Название',
@@ -156,10 +152,10 @@ class WardrobeItemFormType extends AbstractType
 
     public function configureOptions(OptionsResolver $resolver): void
     {
+        // Опция `full` (быстрое добавление против полной карточки) убрана вместе с самим
+        // режимом: и «Добавить вещь», и редактирование открывают полную форму.
         $resolver->setDefaults([
             'data_class' => WardrobeItem::class,
-            'full' => true,
         ]);
-        $resolver->setAllowedTypes('full', 'bool');
     }
 }

--- a/templates/account/wardrobe/form.html.twig
+++ b/templates/account/wardrobe/form.html.twig
@@ -92,6 +92,15 @@
     {% endif %}
     {{ form_widget(form.photoFile, {'attr': {'class': 'block w-full text-sm text-gray-600 file:mr-3 file:rounded-lg file:border-0 file:bg-gray-900 file:px-4 file:py-2 file:text-sm file:font-semibold file:text-white hover:file:bg-black'}}) }}
     {{ f.err(form.photoFile) }}
+    <div class="mt-4">
+        <label class="{{ tw_label }}">Дополнительные фотографии</label>
+        {{ form_widget(form.galleryPhotos, {'attr': {
+            'class': 'block w-full text-sm text-gray-600 file:mr-3 file:rounded-lg file:border-0 file:bg-gray-100 file:px-4 file:py-2 file:text-sm file:font-semibold file:text-gray-700 hover:file:bg-gray-200',
+            'accept': 'image/jpeg,image/png,image/webp'
+        }}) }}
+        {{ f.err(form.galleryPhotos) }}
+        <p class="mt-1 text-xs text-gray-400">До 8 файлов JPG, PNG или WebP, каждый до 10 МБ.</p>
+    </div>
     <div id="wardrobe-ai-photo-status" class="mt-2 hidden text-xs"></div>
     <div id="wardrobe-ai-photo-diff" class="mt-2 hidden"></div>
 </div>
@@ -172,7 +181,7 @@
 
 <div class="mt-6 flex gap-2">
     <button type="submit" class="rounded-xl bg-gray-900 px-6 py-2.5 text-sm font-semibold text-white hover:bg-black transition">Сохранить</button>
-    {% if not fullMode %}
+    {% if not item.id %}
         <button type="submit" name="save_and_add" value="1" class="rounded-xl border border-gray-900 px-5 py-2.5 text-sm font-semibold text-gray-900 hover:bg-gray-50 transition">Сохранить и добавить следующую</button>
     {% endif %}
     <a href="{{ path('account_wardrobe_index') }}"

--- a/templates/account/wardrobe/form.html.twig
+++ b/templates/account/wardrobe/form.html.twig
@@ -24,13 +24,12 @@
 {# ── Основное ── #}
 <div class="mb-4 rounded-2xl bg-white p-6 shadow-sm">
     <div class="mb-4 flex items-center justify-between gap-3">
-        <h2 class="text-sm font-bold">{{ fullMode ? 'Полная карточка' : 'Быстрое добавление' }}</h2>
+        <h2 class="text-sm font-bold">Полная карточка</h2>
         {% if item.id %}
             <span class="rounded-full bg-gray-100 px-3 py-1 text-xs font-semibold text-gray-600">{{ item.completionStatusLabel }}</span>
         {% endif %}
     </div>
     <div class="grid grid-cols-12 gap-4">
-        {% if fullMode %}
         <div class="col-span-12 md:col-span-6">
             <label class="{{ tw_label }}">Категория</label>
             {{ form_widget(form.categoryRef, {'attr': {'class': tw_input}}) }}
@@ -41,7 +40,6 @@
             {{ form_widget(form.name, {'attr': {'class': tw_input, 'placeholder': 'Белая футболка oversize'}}) }}
             {{ f.err(form.name) }}
         </div>
-        {% endif %}
         <div class="col-span-4">
             <label class="{{ tw_label }}">Размер</label>
             {{ form_widget(form.size, {'attr': {'class': tw_input, 'placeholder': 'M'}}) }}
@@ -71,9 +69,6 @@
             <div id="wardrobe-ai-url-preview" class="mt-2 hidden"></div>
         </div>
     </div>
-    {% if not fullMode %}
-        <p class="mt-4 text-xs text-gray-500">Этого достаточно для черновика. Название, категорию, состав и уход можно добавить позже.</p>
-    {% endif %}
 </div>
 
 {# ── Фото ── #}
@@ -119,17 +114,14 @@
             {{ form_widget(form.loveAtFirstSight, {'attr': {'class': tw_input}}) }}
             {{ f.err(form.loveAtFirstSight) }}
         </div>
-        {% if fullMode %}
         <div class="col-span-12">
             <label class="{{ tw_label }}">Характеристики</label>
             {{ form_widget(form.notes, {'attr': {'class': tw_input, 'rows': 3, 'placeholder': 'Состав, уход, особенности…'}}) }}
             {{ f.err(form.notes) }}
         </div>
-        {% endif %}
     </div>
 </div>
 
-{% if fullMode %}
 {# ── Характеристики полной карточки ── #}
 <div class="mb-4 rounded-2xl bg-white p-6 shadow-sm">
     <h2 class="mb-4 text-sm font-bold">Характеристики и уход</h2>
@@ -177,7 +169,6 @@
         </div>
     </div>
 </div>
-{% endif %}
 
 <div class="mt-6 flex gap-2">
     <button type="submit" class="rounded-xl bg-gray-900 px-6 py-2.5 text-sm font-semibold text-white hover:bg-black transition">Сохранить</button>

--- a/tests/Controller/WardrobeControllerTest.php
+++ b/tests/Controller/WardrobeControllerTest.php
@@ -76,6 +76,9 @@ class WardrobeControllerTest extends AuthenticatedWebTestCase
 
         $crawler = $client->request('GET', '/account/wardrobe/new');
         $this->assertResponseIsSuccessful();
+        $this->assertSelectorTextContains('body', 'Полная карточка');
+        $this->assertSelectorExists('#wardrobe_item_form_categoryRef');
+        $this->assertSelectorExists('#wardrobe_item_form_galleryPhotos');
         $this->assertSelectorExists('select[name="wardrobe_item_form[loveAtFirstSight]"]');
 
         $form = $crawler->selectButton('Сохранить')->form([
@@ -114,6 +117,53 @@ class WardrobeControllerTest extends AuthenticatedWebTestCase
         $client->submit($form);
 
         $this->assertResponseRedirects('/account/wardrobe/new');
+    }
+
+    public function testNewItemSavesMultipleGalleryPhotos(): void
+    {
+        $client = static::createClient();
+        $user = $this->loginAsCustomer($client);
+        $firstPath = $this->makeTempImage();
+        $secondPath = $this->makeTempImage();
+
+        $crawler = $client->request('GET', '/account/wardrobe/new');
+        $form = $crawler->selectButton('Сохранить')->form([
+            'wardrobe_item_form[name]' => 'Вещь с галереей',
+            'wardrobe_item_form[size]' => 'M',
+        ]);
+        $client->request('POST', '/account/wardrobe/new', $form->getPhpValues(), [
+            'wardrobe_item_form' => [
+                'galleryPhotos' => [
+                    new UploadedFile($firstPath, 'front.png', 'image/png', null, true),
+                    new UploadedFile($secondPath, 'back.png', 'image/png', null, true),
+                ],
+            ],
+        ]);
+
+        $this->assertResponseRedirects('/account/wardrobe');
+
+        /** @var EntityManagerInterface $em */
+        $em = static::getContainer()->get('doctrine.orm.entity_manager');
+        $item = $em->getRepository(WardrobeItem::class)->findOneBy([
+            'user' => $user,
+            'name' => 'Вещь с галереей',
+        ]);
+        self::assertNotNull($item);
+        self::assertCount(2, $item->getActivePhotos());
+        self::assertNotNull($item->getPhoto());
+        self::assertSame(1, count(array_filter(
+            $item->getActivePhotos(),
+            static fn (WardrobeItemPhoto $photo): bool => $photo->isCover(),
+        )));
+
+        /** @var StorageInterface $storage */
+        $storage = static::getContainer()->get(StorageInterface::class);
+        foreach ($item->getActivePhotos() as $photo) {
+            $path = $storage->resolvePath($photo, 'file');
+            if ($path !== null) {
+                $this->tmpFiles[] = $path;
+            }
+        }
     }
 
     public function testQuickFormPersistsWildberriesPreviewAsPhoto(): void

--- a/tests/Controller/WardrobeControllerTest.php
+++ b/tests/Controller/WardrobeControllerTest.php
@@ -166,6 +166,81 @@ class WardrobeControllerTest extends AuthenticatedWebTestCase
         }
     }
 
+    /**
+     * Галерея при РЕДАКТИРОВАНИИ — путь сложнее создания: у вещи уже есть обложка,
+     * отрабатывает backfillLegacyCoverRow и продолжается нумерация sortOrder. Именно
+     * здесь легко сломать обложку следующей правкой и не заметить.
+     */
+    public function testEditFormAddsGalleryPhotosKeepingExistingCover(): void
+    {
+        $client = static::createClient();
+        $user   = $this->loginAsCustomer($client);
+        $em     = static::getContainer()->get('doctrine.orm.entity_manager');
+
+        // Вещь с уже загруженной обложкой (legacy-фото), как после быстрого добавления.
+        $crawler = $client->request('GET', '/account/wardrobe/new');
+        $form    = $crawler->selectButton('Сохранить')->form(['wardrobe_item_form[name]' => 'Вещь с обложкой']);
+        $client->request('POST', '/account/wardrobe/new', $form->getPhpValues(), [
+            'wardrobe_item_form' => ['photoFile' => ['file' => new UploadedFile($this->makeTempImage(), 'cover.png', 'image/png', null, true)]],
+        ]);
+        $this->assertResponseRedirects();
+
+        $item = $em->getRepository(WardrobeItem::class)->findOneBy(['user' => $user, 'name' => 'Вещь с обложкой']);
+        self::assertNotNull($item);
+        $coverBefore = $item->getPhoto();
+        self::assertNotNull($coverBefore, 'обложка должна была загрузиться');
+
+        $crawler = $client->request('GET', '/account/wardrobe/' . $item->getId() . '/edit');
+        $this->assertResponseIsSuccessful();
+        $form = $crawler->selectButton('Сохранить')->form(['wardrobe_item_form[name]' => 'Вещь с обложкой']);
+        $client->request('POST', '/account/wardrobe/' . $item->getId() . '/edit', $form->getPhpValues(), [
+            'wardrobe_item_form' => ['galleryPhotos' => [
+                new UploadedFile($this->makeTempImage(), 'second.png', 'image/png', null, true),
+                new UploadedFile($this->makeTempImage(), 'third.png', 'image/png', null, true),
+            ]],
+        ]);
+        $this->assertResponseRedirects();
+
+        $em->clear();
+        $fresh = $em->getRepository(WardrobeItem::class)->find($item->getId());
+        self::assertCount(3, $fresh->getActivePhotos(), 'обложка + две новые фотографии');
+        self::assertSame($coverBefore, $fresh->getPhoto(), 'существующая обложка не должна подмениться новой');
+        self::assertSame(1, count(array_filter(
+            $fresh->getActivePhotos(),
+            static fn (WardrobeItemPhoto $photo): bool => $photo->isCover(),
+        )), 'обложка ровно одна');
+
+        /** @var StorageInterface $storage */
+        $storage = static::getContainer()->get(StorageInterface::class);
+        foreach ($fresh->getActivePhotos() as $photo) {
+            $path = $storage->resolvePath($photo, 'file');
+            if ($path !== null) {
+                $this->tmpFiles[] = $path;
+            }
+        }
+    }
+
+    /** Лишние файлы отсекает форма (422), а не загрузчик 500-й: вещь при этом не создаётся. */
+    public function testTooManyGalleryPhotosAreRejectedByForm(): void
+    {
+        $client = static::createClient();
+        $this->loginAsCustomer($client);
+
+        $crawler = $client->request('GET', '/account/wardrobe/new');
+        $form    = $crawler->selectButton('Сохранить')->form(['wardrobe_item_form[name]' => 'Девять файлов']);
+        $files   = [];
+        for ($i = 0; $i < 9; $i++) {
+            $files[] = new UploadedFile($this->makeTempImage(), "f{$i}.png", 'image/png', null, true);
+        }
+        $client->request('POST', '/account/wardrobe/new', $form->getPhpValues(), ['wardrobe_item_form' => ['galleryPhotos' => $files]]);
+
+        self::assertSame(422, $client->getResponse()->getStatusCode());
+        self::assertStringContainsString('не больше 8', (string) $client->getResponse()->getContent());
+
+        $em = static::getContainer()->get('doctrine.orm.entity_manager');
+        self::assertNull($em->getRepository(WardrobeItem::class)->findOneBy(['name' => 'Девять файлов']));
+    }
+
     public function testQuickFormPersistsWildberriesPreviewAsPhoto(): void
     {
         $client = static::createClient();


### PR DESCRIPTION
## Что изменено

- при нажатии «Добавить вещь» сразу открывается полная форма карточки
- к основному фото можно выбрать до 8 дополнительных JPG, PNG или WebP по 10 МБ
- галерея сохраняется как при создании, так и при редактировании вещи
- существующая загрузка основного фото и использование его для AI-подсказок сохранены
- если основного фото нет, менеджер фотографий назначает первую фотографию галереи обложкой

## Проверка

- PHP syntax check — успешно
- Twig lint — успешно
- Symfony container lint — успешно
- `WardrobeControllerTest`: 47 тестов, 255 проверок — успешно

Примечание: PHPUnit сообщает одно предупреждение об устаревшем nullable-типе во внешней зависимости `nevinny/admin-core`; оно не связано с этим PR.