### PR TITLE
test(seo): покрыть запись findings тех-аудита и дельту

### DIFF
--- a/src/Command/SeoTechAuditCommand.php
+++ b/src/Command/SeoTechAuditCommand.php
@@ -685,21 +685,35 @@ class SeoTechAuditCommand extends Command
                 $new[] = ['url' => $f['url'], 'rule' => $f['rule']];
             }
 
-            $this->db->executeStatement(
-                'INSERT INTO seo_tech_finding (url, rule, detail, first_seen_on, last_seen_on, fixed_on)
-                 VALUES (:url, :rule, :detail, :day, :day, NULL)
-                 ON DUPLICATE KEY UPDATE
-                    detail = VALUES(detail),
-                    last_seen_on = VALUES(last_seen_on),
-                    first_seen_on = IF(fixed_on IS NULL, first_seen_on, VALUES(first_seen_on)),
-                    fixed_on = NULL',
-                [
-                    'url'    => mb_substr($f['url'], 0, 512),
-                    'rule'   => $f['rule'],
-                    'detail' => mb_substr($f['detail'], 0, 255),
-                    'day'    => $today,
-                ],
+            $url    = mb_substr($f['url'], 0, 512);
+            $detail = mb_substr($f['detail'], 0, 255);
+
+            // SELECT-then-write вместо ON DUPLICATE KEY UPDATE: тот был MySQL-only, из-за
+            // чего весь путь записи не покрывался тестами (тест-БД — SQLite). Гонок здесь
+            // нет: аудит гоняет один крон.
+            $existing = $this->db->fetchAssociative(
+                'SELECT id, fixed_on FROM seo_tech_finding WHERE url = ? AND rule = ?',
+                [$url, $f['rule']],
             );
+
+            if ($existing === false) {
+                $this->db->insert('seo_tech_finding', [
+                    'url' => $url, 'rule' => $f['rule'], 'detail' => $detail,
+                    'first_seen_on' => $today, 'last_seen_on' => $today, 'fixed_on' => null,
+                ]);
+                continue;
+            }
+
+            // Нарушение, всплывшее после исправления, — это «появилось» заново,
+            // поэтому first_seen_on сдвигаем; у открытого дату первой встречи храним.
+            $sql = $existing['fixed_on'] === null
+                ? 'UPDATE seo_tech_finding SET detail = ?, last_seen_on = ? WHERE id = ?'
+                : 'UPDATE seo_tech_finding SET detail = ?, last_seen_on = ?, first_seen_on = ?, fixed_on = NULL WHERE id = ?';
+            $params = $existing['fixed_on'] === null
+                ? [$detail, $today, $existing['id']]
+                : [$detail, $today, $today, $existing['id']];
+
+            $this->db->executeStatement($sql, $params);
         }
 
         $fixed = [];

--- a/tests/Command/SeoTechAuditCommandTest.php
+++ b/tests/Command/SeoTechAuditCommandTest.php
@@ -14,9 +14,8 @@ use Symfony\Component\HttpClient\Response\MockResponse;
 
 /**
  * Тех-аудит (app:seo:tech-audit) на синтетическом сайте через MockHttpClient — сеть не
- * нужна. Прогон только с --stdout-only: seo_tech_finding — сырая (не-entity) таблица,
- * в SQLite-схему тестов она не провижинится, а проверять здесь надо логику обхода и
- * правил, а не upsert.
+ * нужна. Проверки правил гоняем с --stdout-only, а запись findings и дельту —
+ * без него: seo_tech_finding мирроится в SQLite-схему тестов (tests/bootstrap.php).
  */
 class SeoTechAuditCommandTest extends KernelTestCase
 {
@@ -131,6 +130,81 @@ class SeoTechAuditCommandTest extends KernelTestCase
         self::assertStringContainsString('Страница-сирота', $out);
         self::assertStringContainsString('/ru/blog/orphan', $out);
         self::assertStringNotContainsString('/ru/blog/linked —', $out);
+    }
+
+    /**
+     * Путь записи findings и дельта «появилось / исправлено» — ради неё и заведена
+     * seo_tech_finding: без дельты еженедельный отчёт присылал бы один и тот же список.
+     * Исправленное закрывается через fixed_on (soft-delete), а не удаляется.
+     */
+    public function testFindingsArePersistedAndDeltaTracksFixes(): void
+    {
+        $db = self::getContainer()->get(Connection::class);
+        $db->executeStatement('DELETE FROM seo_tech_finding');
+
+        // Прогон 1: на странице два H1 → нарушение открыто.
+        $broken = '<html><head><title>Сломанная</title>'
+            . '<meta name="description" content="Достаточно длинное описание, чтобы правило про короткий description молчало на этой странице.">'
+            . '<link rel="canonical" href="https://example.test/ru/fix-me"></head>'
+            . '<body><h1>Раз</h1><h1>Два</h1></body></html>';
+
+        $this->tester([
+            '/'            => self::page('Главная', '<h1>Главная</h1><a href="/ru/fix-me">чинить</a>'),
+            '/ru/fix-me'   => $broken,
+            '/sitemap.xml' => '<urlset><url><loc>https://example.test/</loc></url></urlset>',
+        ])->execute(['--delay-ms' => '0', '--link-check-cap' => '0']);
+
+        $row = $db->fetchAssociative("SELECT * FROM seo_tech_finding WHERE rule = 'h1_multiple'");
+        self::assertNotFalse($row, 'нарушение должно записаться');
+        self::assertSame('/ru/fix-me', $row['url']);
+        self::assertNull($row['fixed_on']);
+
+        // Прогон 2: тот же обход, H1 починили → строка закрывается, а не исчезает.
+        $tester = $this->tester([
+            '/'            => self::page('Главная', '<h1>Главная</h1><a href="/ru/fix-me">чинить</a>'),
+            '/ru/fix-me'   => self::page('Починенная', '<h1>Один</h1>'),
+            '/sitemap.xml' => '<urlset><url><loc>https://example.test/</loc></url></urlset>',
+        ]);
+        $tester->execute(['--delay-ms' => '0', '--link-check-cap' => '0']);
+
+        self::assertStringContainsString('исправлено: 1', $tester->getDisplay());
+        $row = $db->fetchAssociative("SELECT * FROM seo_tech_finding WHERE rule = 'h1_multiple'");
+        self::assertNotFalse($row, 'история не удаляется — только помечается исправленной');
+        self::assertNotNull($row['fixed_on']);
+
+        // Прогон 3: сломали снова → та же строка снова открыта и считается новой.
+        $tester = $this->tester([
+            '/'            => self::page('Главная', '<h1>Главная</h1><a href="/ru/fix-me">чинить</a>'),
+            '/ru/fix-me'   => $broken,
+            '/sitemap.xml' => '<urlset><url><loc>https://example.test/</loc></url></urlset>',
+        ]);
+        $tester->execute(['--delay-ms' => '0', '--link-check-cap' => '0']);
+
+        self::assertStringContainsString('появилось: 1', $tester->getDisplay());
+        $row = $db->fetchAssociative("SELECT * FROM seo_tech_finding WHERE rule = 'h1_multiple'");
+        self::assertNull($row['fixed_on']);
+        self::assertSame(1, (int) $db->fetchOne("SELECT COUNT(*) FROM seo_tech_finding WHERE rule = 'h1_multiple'"), 'дубля быть не должно');
+    }
+
+    /** Чужие правила аудит не закрывает: в таблице живут находки app:yandex:sync. */
+    public function testForeignRuleIsNotClosedByAudit(): void
+    {
+        $db = self::getContainer()->get(Connection::class);
+        $db->executeStatement('DELETE FROM seo_tech_finding');
+        $db->insert('seo_tech_finding', [
+            'url' => '/ru/from-yandex', 'rule' => 'yandex_broken_link', 'detail' => 'Вебмастер',
+            'first_seen_on' => '2026-07-01', 'last_seen_on' => '2026-07-01', 'fixed_on' => null,
+        ]);
+
+        $this->tester([
+            '/'            => self::page('Главная', '<h1>Главная</h1>'),
+            '/sitemap.xml' => '<urlset><url><loc>https://example.test/</loc></url></urlset>',
+        ])->execute(['--delay-ms' => '0', '--link-check-cap' => '0']);
+
+        self::assertNull(
+            $db->fetchOne("SELECT fixed_on FROM seo_tech_finding WHERE rule = 'yandex_broken_link'"),
+            'находка другого источника не участвует в этом обходе и закрываться не должна',
+        );
     }
 
     public function testOrphanCheckIsSkippedWhenHubPhaseHitsItsCap(): void

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -59,6 +59,19 @@ if (($_SERVER['APP_ENV'] ?? null) === 'test') {
             )
         SQL);
 
+        // Находки тех-аудита с дельтой (Version20260728_seo_tech_finding).
+        $connection->executeStatement(<<<'SQL'
+            CREATE TABLE IF NOT EXISTS seo_tech_finding (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                url VARCHAR(512) NOT NULL,
+                rule VARCHAR(40) NOT NULL,
+                detail VARCHAR(255) DEFAULT NULL,
+                first_seen_on DATE NOT NULL,
+                last_seen_on DATE NOT NULL,
+                fixed_on DATE DEFAULT NULL
+            )
+        SQL);
+
         // Карта идемпотентности переноса гардероба (Version20260728_wardrobe_import_map).
         $connection->executeStatement(<<<'SQL'
             CREATE TABLE IF NOT EXISTS wardrobe_import_map (


### PR DESCRIPTION
Пробел нашёлся при ревью собственного кода: путь записи в `seo_tech_finding` ни разу не исполнялся — все прогоны и тесты шли с `--stdout-only`, первым исполнением стал бы субботний крон.

Причина непроверяемости — `ON DUPLICATE KEY UPDATE`: MySQL-only, а тест-БД на SQLite. Заменил на портируемый SELECT-then-INSERT/UPDATE (гонок нет, аудит гоняет один крон) и замиррорил таблицу в `tests/bootstrap.php`.

Тесты закрывают смысл таблицы: нарушение записывается → закрывается через `fixed_on` (история не удаляется) → при повторном появлении та же строка снова открывается и считается новой, без дубля. Отдельно — что находки чужого источника (`yandex_broken_link` от `app:yandex:sync`) аудит не закрывает.

Проверено и на настоящей MySQL: прогон без `--stdout-only` записал находку и не тронул 7 закрытых строк Яндекса.