### PR TITLE
ЛК бренда: управление ссылками (сайт/соцсети)

### DIFF
--- a/src/Controller/BrandLk/BrandLinkController.php
+++ b/src/Controller/BrandLk/BrandLinkController.php
@@ -1,0 +1,174 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller\BrandLk;
+
+use App\Entity\Brand;
+use App\Entity\BrandDatapoint;
+use App\Entity\BrandLink;
+use App\Form\BrandLk\BrandLinkFormType;
+use App\Repository\BrandDatapointRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Nevinny\AdminCoreBundle\Enum\Statuses;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+/**
+ * ЛК бренда: управление ссылками (сайт/соцсети, BrandLink). До этого ссылки жили
+ * только из enrichment'а — теперь владелец вносит/правит сам.
+ *
+ * Owner-provenance — тот же приём, что в BrandStoreController::markOwnerProvenance():
+ * owner-правка помечает datapoint'ы ссылки provenance=owner + ownerEditedAt, так что
+ * ре-обогащение их не затирает.
+ */
+#[Route('/brand/links', name: 'brand_links')]
+class BrandLinkController extends BrandDashboardController
+{
+    private const MAX_LINKS_PER_BRAND = 8;
+
+    #[Route('', name: '')]
+    public function index(Request $request): Response
+    {
+        $brand = $this->getActiveBrand();
+
+        $editLink = null;
+        if ($request->query->has('edit')) {
+            $editLink = $this->findOwnLink((int) $request->query->get('edit'));
+        }
+
+        $form = $this->createForm(BrandLinkFormType::class, $editLink ?? new BrandLink());
+
+        return $this->render('brand_lk/links.html.twig', [
+            'brand'    => $brand,
+            'links'    => $brand->getActiveLinks(),
+            'form'     => $form,
+            'editLink' => $editLink,
+        ]);
+    }
+
+    #[Route('/save', name: '_save', methods: ['POST'])]
+    public function save(Request $request, EntityManagerInterface $em): Response
+    {
+        $brand = $this->getActiveBrand();
+
+        $id   = $request->request->getInt('id');
+        $link = null;
+        if ($id > 0) {
+            $link = $this->findOwnLink($id);
+            if ($link === null) {
+                // Чужая ссылка или мусорный id — 404 (IDOR), не палим существование чужого бренда.
+                throw $this->createNotFoundException('Ссылка не найдена.');
+            }
+        }
+
+        $isNew = $link === null;
+        if ($isNew && $brand->getActiveLinks()->count() >= self::MAX_LINKS_PER_BRAND) {
+            $this->addFlash('danger', sprintf('Можно добавить не больше %d ссылок на бренд.', self::MAX_LINKS_PER_BRAND));
+            return $this->redirectToRoute('brand_links');
+        }
+
+        $link ??= new BrandLink();
+        $form = $this->createForm(BrandLinkFormType::class, $link);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            if ($this->isDuplicateUrl($brand, $link)) {
+                $this->addFlash('danger', 'Такая ссылка уже добавлена.');
+                return $this->redirectToRoute('brand_links');
+            }
+
+            if ($isNew) {
+                $link->setBrand($brand);
+                // DefaultFields требует slug NOT NULL — тот же приём, что в enrichment
+                // (BrandIngestService/EnrichBrandContactsCommand): генерируем из типа+URL.
+                $link->setSlug(substr(md5($link->getLinkType() . $link->getLinkUrl()), 0, 24));
+                $em->persist($link);
+            }
+            $em->flush(); // link.id нужен для datapoint'ов новой ссылки
+
+            $this->markOwnerProvenance($link, $em);
+            $em->flush();
+
+            $this->addFlash('success', $isNew ? 'Ссылка добавлена.' : 'Ссылка обновлена.');
+
+            return $this->redirectToRoute('brand_links');
+        }
+
+        return $this->render('brand_lk/links.html.twig', [
+            'brand'    => $brand,
+            'links'    => $brand->getActiveLinks(),
+            'form'     => $form,
+            'editLink' => $isNew ? null : $link,
+        ]);
+    }
+
+    #[Route('/{id}/delete', name: '_delete', methods: ['POST'])]
+    public function delete(int $id, Request $request, EntityManagerInterface $em): Response
+    {
+        // Ownership-проверка ПЕРЕД CSRF (как в WardrobeController::resolvePhotoAction) —
+        // чужая/несуществующая ссылка всегда 404, независимо от токена (IDOR не палит существование).
+        $link = $this->findOwnLink($id);
+        if ($link === null) {
+            throw $this->createNotFoundException('Ссылка не найдена.');
+        }
+
+        if (!$this->isCsrfTokenValid('brand_links', (string) $request->request->get('_token'))) {
+            $this->addFlash('danger', 'Недействительный токен. Обновите страницу.');
+            return $this->redirectToRoute('brand_links');
+        }
+
+        // Правило проекта: НИКАКОГО физического DELETE от пользователя — только soft.
+        $link->setStatus(Statuses::Deleted);
+        $em->flush();
+
+        $this->addFlash('success', 'Ссылка удалена.');
+
+        return $this->redirectToRoute('brand_links');
+    }
+
+    /** Ссылка активного бренда пользователя (не чужая и не удалённая). */
+    private function findOwnLink(int $id): ?BrandLink
+    {
+        $brand = $this->getActiveBrand();
+        foreach ($brand->getActiveLinks() as $link) {
+            if ($link->getId() === $id) {
+                return $link;
+            }
+        }
+
+        return null;
+    }
+
+    /** Дубль по нормализованному URL среди активных ссылок бренда (кроме самой редактируемой). */
+    private function isDuplicateUrl(Brand $brand, BrandLink $link): bool
+    {
+        $normalized = mb_strtolower(rtrim((string) $link->getLinkUrl(), '/'));
+        foreach ($brand->getActiveLinks() as $existing) {
+            if ($existing->getId() === $link->getId()) {
+                continue;
+            }
+            if (mb_strtolower(rtrim((string) $existing->getLinkUrl(), '/')) === $normalized) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /** Owner-правка: provenance=owner + ownerEditedAt на все поля ссылки, счётчики голосов сбрасываются. */
+    private function markOwnerProvenance(BrandLink $link, EntityManagerInterface $em): void
+    {
+        /** @var BrandDatapointRepository $repo */
+        $repo = $em->getRepository(BrandDatapoint::class);
+        foreach (BrandDatapoint::FIELDS[BrandDatapoint::TYPE_LINK] as $field) {
+            $repo->getOrCreate($link->getBrand(), BrandDatapoint::TYPE_LINK, $link->getId(), $field)
+                ->setProvenance(BrandDatapoint::PROV_OWNER)
+                ->setOwnerEditedAt(new \DateTime())
+                ->setState(BrandDatapoint::STATE_ACTIVE)
+                ->setConfirmCount(0)->setRejectCount(0)->setRejectWindow(0)
+                ->setQueuedRevalidateAt(null);
+        }
+    }
+}

--- a/src/Entity/Brand.php
+++ b/src/Entity/Brand.php
@@ -682,7 +682,8 @@ class Brand
 
     /**
      * Ссылки без дублей по нормализованному URL (в brand_link встречаются повторы,
-     * напр. один и тот же wa.me дважды). Порядок сохраняется. Дедуп на уровне модели,
+     * напр. один и тот же wa.me дважды) и без soft-deleted (правило проекта: DELETE
+     * от пользователя только мягкий). Порядок сохраняется. Дедуп на уровне модели,
      * чтобы представление (шаблон/JSON-LD) не занималось этой логикой.
      *
      * @return list<BrandLink>
@@ -692,6 +693,9 @@ class Brand
         $seen = [];
         $out  = [];
         foreach ($this->links as $link) {
+            if ($link->getStatus() === Statuses::Deleted) {
+                continue;
+            }
             $key = mb_strtolower(rtrim((string) $link->getLinkUrl(), '/'));
             if ($key === '' || isset($seen[$key])) {
                 continue;
@@ -701,6 +705,17 @@ class Brand
         }
 
         return $out;
+    }
+
+    /**
+     * Ссылки без soft-deleted (для ЛК бренда; см. getActiveStores).
+     * @return Collection<int, BrandLink>
+     */
+    public function getActiveLinks(): Collection
+    {
+        return $this->links->filter(
+            static fn(BrandLink $l) => $l->getStatus() !== Statuses::Deleted
+        );
     }
 
     public function addLink(BrandLink $link): static

--- a/src/Form/BrandLk/BrandLinkFormType.php
+++ b/src/Form/BrandLk/BrandLinkFormType.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Form\BrandLk;
+
+use App\Entity\BrandLink;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\UrlType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraints\Length;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Constraints\Url;
+
+/**
+ * Форма ссылки бренда (ЛК). Типы — фиксированный список из докблока
+ * App\Entity\BrandLink::$linkType (свободная строка в сущности, но выбор
+ * пользователя ограничен ChoiceType — не свободный текст).
+ */
+class BrandLinkFormType extends AbstractType
+{
+    private const LINK_TYPES = [
+        'Сайт'      => 'website',
+        'Instagram' => 'instagram',
+        'VK'        => 'vk',
+        'Telegram'  => 'telegram',
+        'YouTube'   => 'youtube',
+        'TikTok'    => 'tiktok',
+        'Другое'    => 'other',
+    ];
+
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('linkType', ChoiceType::class, [
+                'label'   => 'Тип ссылки',
+                'choices' => self::LINK_TYPES,
+            ])
+            ->add('linkUrl', UrlType::class, [
+                'label'            => 'Ссылка',
+                // null — не достраивать протокол автоматически: строка без схемы должна
+                // быть отклонена валидацией, а не тихо превращена в https://строка.
+                'default_protocol' => null,
+                'constraints'      => [
+                    new NotBlank(message: 'Укажите ссылку.'),
+                    new Length(max: 255),
+                    // requireTld: false — сохраняем текущее (pre-8.0) поведение явно, без deprecation-предупреждения.
+                    new Url(protocols: ['http', 'https'], requireTld: false),
+                ],
+            ]);
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults(['data_class' => BrandLink::class]);
+    }
+}

--- a/templates/brand_lk/layout.html.twig
+++ b/templates/brand_lk/layout.html.twig
@@ -26,6 +26,7 @@
             <li><a class="{{ route starts with 'brand_media' ? lk_active : lk_item }}" href="{{ path('brand_media') }}">Медиа</a></li>
             <li><a class="{{ route starts with 'brand_product' ? lk_active : lk_item }}" href="{{ path('brand_products') }}">Товары</a></li>
             <li><a class="{{ route starts with 'brand_stores' ? lk_active : lk_item }}" href="{{ path('brand_stores') }}">Магазины</a></li>
+            <li><a class="{{ route starts with 'brand_links' ? lk_active : lk_item }}" href="{{ path('brand_links') }}">Ссылки</a></li>
             <li>
                 <a class="{{ route starts with 'brand_order' ? lk_active : lk_item }}" href="{{ path('brand_orders') }}">
                     Заказы

--- a/templates/brand_lk/links.html.twig
+++ b/templates/brand_lk/links.html.twig
@@ -1,0 +1,82 @@
+{% extends 'brand_lk/layout.html.twig' %}
+
+{% block title %}Ссылки — {{ brand.title }} — WEARBASE{% endblock %}
+
+{% macro err(field) %}
+    {% if field.vars.errors|length > 0 %}
+        <div class="form-error mt-1 text-sm text-red-600">{{ form_errors(field) }}</div>
+    {% endif %}
+{% endmacro %}
+
+{% block brand_content %}
+{% import _self as f %}
+{% set input_class = 'w-full rounded-lg border border-gray-200 bg-white px-3 py-2.5 text-sm placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-gray-900' %}
+{% set label_class = 'block text-[11px] font-semibold uppercase tracking-wider text-gray-500 mb-1' %}
+
+<div class="mb-5 flex items-center justify-between">
+    <h1 class="text-lg font-bold">Ссылки бренда</h1>
+</div>
+
+{# Форма добавления/редактирования #}
+<div class="mb-6 rounded-2xl bg-white shadow-sm">
+    <div class="p-5">
+        <h2 class="mb-3 text-sm font-semibold">{{ editLink ? 'Редактировать ссылку' : 'Добавить ссылку' }}</h2>
+        {{ form_start(form, {'action': path('brand_links_save'), 'attr': {'class': 'grid gap-4 md:grid-cols-2'}}) }}
+            {% if editLink %}<input type="hidden" name="id" value="{{ editLink.id }}">{% endif %}
+            <div>
+                <label class="{{ label_class }}">Тип ссылки</label>
+                {{ form_widget(form.linkType, {'attr': {'class': input_class}}) }}
+                {{ f.err(form.linkType) }}
+            </div>
+            <div>
+                <label class="{{ label_class }}">Ссылка</label>
+                {{ form_widget(form.linkUrl, {'attr': {'class': input_class, 'placeholder': 'https://...'}}) }}
+                {{ f.err(form.linkUrl) }}
+            </div>
+            <div class="flex items-center gap-2 md:col-span-2">
+                <button type="submit" class="rounded-xl bg-gray-900 px-5 py-2.5 text-sm font-semibold text-white hover:bg-black transition">{{ editLink ? 'Сохранить' : 'Добавить' }}</button>
+                {% if editLink %}
+                    <a href="{{ path('brand_links') }}" class="rounded-lg border border-gray-300 px-3 py-1.5 text-sm text-gray-600 hover:bg-gray-50 transition">Отмена</a>
+                {% endif %}
+            </div>
+        {{ form_end(form) }}
+    </div>
+</div>
+
+{# Список ссылок #}
+<div class="overflow-hidden rounded-2xl bg-white shadow-sm">
+    {% if links|length == 0 %}
+        <div class="p-5">
+            <p class="text-sm text-gray-500">Ссылки не добавлены. Максимум — 8 ссылок на бренд.</p>
+        </div>
+    {% else %}
+        <div class="overflow-x-auto">
+            <table class="w-full text-sm">
+                <thead class="bg-gray-50 text-left text-xs font-semibold uppercase tracking-wider text-gray-500">
+                    <tr>
+                        <th class="px-5 py-3">Тип</th>
+                        <th class="px-5 py-3">Ссылка</th>
+                        <th class="px-5 py-3 text-right"></th>
+                    </tr>
+                </thead>
+                <tbody class="divide-y divide-gray-100">
+                    {% for link in links %}
+                        <tr>
+                            <td class="px-5 py-3">{{ link.linkType }}</td>
+                            <td class="px-5 py-3 break-all">{{ link.linkUrl }}</td>
+                            <td class="whitespace-nowrap px-5 py-3 text-right">
+                                <a href="{{ path('brand_links', {edit: link.id}) }}" class="rounded-lg border border-gray-300 px-3 py-1.5 text-sm text-gray-600 hover:bg-gray-50 transition">Изменить</a>
+                                <form method="post" action="{{ path('brand_links_delete', {id: link.id}) }}" class="inline"
+                                      onsubmit="return confirm('Удалить ссылку?')">
+                                    <input type="hidden" name="_token" value="{{ csrf_token('brand_links') }}">
+                                    <button type="submit" class="rounded-lg border border-red-300 px-3 py-1.5 text-sm text-red-600 hover:bg-red-50 transition">Удалить</button>
+                                </form>
+                            </td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    {% endif %}
+</div>
+{% endblock %}

--- a/tests/Controller/BrandLinkControllerTest.php
+++ b/tests/Controller/BrandLinkControllerTest.php
@@ -1,0 +1,242 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Controller;
+
+use App\Entity\Brand;
+use App\Entity\BrandLink;
+use Doctrine\ORM\EntityManagerInterface;
+use Nevinny\AdminCoreBundle\Enum\Statuses;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+/**
+ * Integration tests for brand LK link management: /brand/links/*
+ *
+ * Run with: php bin/phpunit tests/Controller/BrandLinkControllerTest.php
+ */
+class BrandLinkControllerTest extends AuthenticatedWebTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->skipIfNoDatabase();
+    }
+
+    /**
+     * 'Test Brand' — общая идемпотентная фикстура (UserFactory::brandOwnerWithBrand),
+     * переиспользуется всеми тестами прогона. Чистим ссылки, созданные ЭТИМ тестом,
+     * иначе assertCount() в соседних тестах зависят от порядка выполнения.
+     * Физический DELETE — тестовая уборка, не действие пользователя (правило soft-delete
+     * не про это; см. CLAUDE.md «системные операции»).
+     */
+    protected function tearDown(): void
+    {
+        /** @var EntityManagerInterface $em */
+        $em   = static::getContainer()->get('doctrine.orm.entity_manager');
+        $conn = $em->getConnection();
+        $conn->executeStatement(
+            "DELETE FROM brand_link WHERE brand_id IN (SELECT id FROM brand WHERE slug = 'test-brand-lk' OR slug LIKE 'foreign-brand-%')"
+        );
+        $conn->executeStatement("DELETE FROM brand WHERE slug LIKE 'foreign-brand-%'");
+        parent::tearDown();
+    }
+
+    public function testOwnerCanAddLinkAndItAppearsInLkAndOnBrandPage(): void
+    {
+        $client = static::createClient();
+        [, $brand] = $this->loginAsBrandOwnerWithBrand($client);
+
+        $crawler = $client->request('GET', '/brand/links');
+        $this->assertResponseIsSuccessful();
+
+        $form = $crawler->selectButton('Добавить')->form([
+            'brand_link_form[linkType]' => 'website',
+            'brand_link_form[linkUrl]'  => 'https://example.com',
+        ]);
+        $client->submit($form);
+
+        $this->assertResponseRedirects('/brand/links');
+
+        /** @var EntityManagerInterface $em */
+        $em = static::getContainer()->get('doctrine.orm.entity_manager');
+        $em->clear();
+        /** @var Brand $reloaded */
+        $reloaded = $em->find(Brand::class, $brand->getId());
+        $this->assertCount(1, $reloaded->getActiveLinks());
+
+        $crawler = $client->request('GET', '/brand/links');
+        $this->assertSelectorTextContains('body', 'example.com');
+
+        // «и у бренда» — публичная страница показывает ту же ссылку через прокладку /go/{id}
+        $client->request('GET', '/ru/brands/' . $brand->getSlug());
+        $this->assertResponseIsSuccessful();
+        $this->assertSelectorTextContains('body', 'example.com');
+    }
+
+    public function testForeignLinkCannotBeEditedOrDeleted(): void
+    {
+        $client = static::createClient();
+        $this->loginAsBrandOwnerWithBrand($client);
+
+        /** @var EntityManagerInterface $em */
+        $em = static::getContainer()->get('doctrine.orm.entity_manager');
+        $foreignLink = $this->makeForeignLink($em, 'https://foreign-brand.example.com');
+        $foreignId   = $foreignLink->getId();
+
+        $client->request('POST', '/brand/links/save', [
+            'id'              => $foreignId,
+            'brand_link_form' => ['linkType' => 'website', 'linkUrl' => 'https://hijacked.example.com'],
+        ]);
+        $this->assertResponseStatusCodeSame(404);
+
+        $client->request('POST', '/brand/links/' . $foreignId . '/delete', ['_token' => 'irrelevant']);
+        $this->assertResponseStatusCodeSame(404);
+
+        $em->clear();
+        /** @var BrandLink $stillIntact */
+        $stillIntact = $em->find(BrandLink::class, $foreignId);
+        $this->assertSame('https://foreign-brand.example.com', $stillIntact->getLinkUrl());
+        $this->assertNotSame(Statuses::Deleted, $stillIntact->getStatus());
+    }
+
+    #[DataProvider('invalidUrlProvider')]
+    public function testInvalidUrlIsRejected(string $invalidUrl): void
+    {
+        $client = static::createClient();
+        [, $brand] = $this->loginAsBrandOwnerWithBrand($client);
+
+        $crawler = $client->request('GET', '/brand/links');
+        $form = $crawler->selectButton('Добавить')->form([
+            'brand_link_form[linkType]' => 'website',
+            'brand_link_form[linkUrl]'  => $invalidUrl,
+        ]);
+        $client->submit($form);
+
+        // Symfony 7.3: невалидная форма в render() автоматически получает 422 (см. WardrobeControllerTest).
+        $this->assertResponseStatusCodeSame(422);
+        $this->assertSelectorExists('.form-error');
+
+        /** @var EntityManagerInterface $em */
+        $em = static::getContainer()->get('doctrine.orm.entity_manager');
+        $em->clear();
+        /** @var Brand $reloaded */
+        $reloaded = $em->find(Brand::class, $brand->getId());
+        $this->assertCount(0, $reloaded->getActiveLinks());
+    }
+
+    public static function invalidUrlProvider(): iterable
+    {
+        yield 'javascript scheme' => ['javascript:alert(1)'];
+        yield 'disallowed protocol' => ['ftp://example.com/file'];
+        yield 'no scheme' => ['example.com'];
+    }
+
+    public function testDuplicateUrlIsRejected(): void
+    {
+        $client = static::createClient();
+        [, $brand] = $this->loginAsBrandOwnerWithBrand($client);
+
+        $crawler = $client->request('GET', '/brand/links');
+        $client->submit($crawler->selectButton('Добавить')->form([
+            'brand_link_form[linkType]' => 'website',
+            'brand_link_form[linkUrl]'  => 'https://dup.example.com',
+        ]));
+        $this->assertResponseRedirects('/brand/links');
+
+        $crawler = $client->request('GET', '/brand/links');
+        $client->submit($crawler->selectButton('Добавить')->form([
+            'brand_link_form[linkType]' => 'instagram',
+            'brand_link_form[linkUrl]'  => 'https://dup.example.com',
+        ]));
+        $this->assertResponseRedirects('/brand/links');
+
+        /** @var EntityManagerInterface $em */
+        $em = static::getContainer()->get('doctrine.orm.entity_manager');
+        $em->clear();
+        /** @var Brand $reloaded */
+        $reloaded = $em->find(Brand::class, $brand->getId());
+        $this->assertCount(1, $reloaded->getActiveLinks());
+    }
+
+    public function testNinthLinkIsRejected(): void
+    {
+        $client = static::createClient();
+        [, $brand] = $this->loginAsBrandOwnerWithBrand($client);
+
+        /** @var EntityManagerInterface $em */
+        $em = static::getContainer()->get('doctrine.orm.entity_manager');
+        for ($i = 1; $i <= 8; $i++) {
+            $em->persist($this->newLink($brand, 'other', "https://link{$i}.example.com"));
+        }
+        $em->flush();
+        $em->clear();
+
+        $crawler = $client->request('GET', '/brand/links');
+        $client->submit($crawler->selectButton('Добавить')->form([
+            'brand_link_form[linkType]' => 'website',
+            'brand_link_form[linkUrl]'  => 'https://link9.example.com',
+        ]));
+        $this->assertResponseRedirects('/brand/links');
+
+        $em->clear();
+        /** @var Brand $reloaded */
+        $reloaded = $em->find(Brand::class, $brand->getId());
+        $this->assertCount(8, $reloaded->getActiveLinks());
+    }
+
+    public function testDeleteIsSoftDelete(): void
+    {
+        $client = static::createClient();
+        [, $brand] = $this->loginAsBrandOwnerWithBrand($client);
+
+        /** @var EntityManagerInterface $em */
+        $em = static::getContainer()->get('doctrine.orm.entity_manager');
+        $link = $this->newLink($brand, 'website', 'https://to-delete.example.com');
+        $em->persist($link);
+        $em->flush();
+        $linkId = $link->getId();
+
+        // Токен берём со страницы (crawler), а не из CSRF-сессии напрямую — после
+        // завершения запроса request_stack пуст и SessionTokenStorage бросает исключение.
+        $crawler = $client->request('GET', '/brand/links');
+        $token   = $crawler->filter('form[action*="/delete"] input[name="_token"]')->attr('value');
+        $client->request('POST', '/brand/links/' . $linkId . '/delete', ['_token' => $token]);
+        $this->assertResponseRedirects('/brand/links');
+
+        $crawler = $client->request('GET', '/brand/links');
+        $this->assertSelectorTextNotContains('body', 'to-delete.example.com');
+
+        $client->request('GET', '/ru/brands/' . $brand->getSlug());
+        $this->assertSelectorTextNotContains('body', 'to-delete.example.com');
+
+        $em->clear();
+        /** @var BrandLink $stillThere */
+        $stillThere = $em->find(BrandLink::class, $linkId);
+        $this->assertNotNull($stillThere, 'Физическая строка должна остаться (soft-delete)');
+        $this->assertSame(Statuses::Deleted, $stillThere->getStatus());
+    }
+
+    /** Ссылка чужого бренда — прямая персистенция в обход ЛК (для IDOR-теста). */
+    private function makeForeignLink(EntityManagerInterface $em, string $url): BrandLink
+    {
+        $foreignBrand = (new Brand())->setTitle('Foreign Brand')->setSlug('foreign-brand-' . uniqid());
+        $em->persist($foreignBrand);
+
+        $link = $this->newLink($foreignBrand, 'website', $url);
+        $em->persist($link);
+        $em->flush();
+
+        return $link;
+    }
+
+    /** BrandLink с обязательным (DefaultFields) slug — как в enrichment-командах. */
+    private function newLink(Brand $brand, string $type, string $url): BrandLink
+    {
+        return (new BrandLink())
+            ->setBrand($brand)
+            ->setLinkType($type)
+            ->setLinkUrl($url)
+            ->setSlug(substr(md5($type . $url), 0, 24));
+    }
+}

--- a/tests/Controller/BrandLkControllerTest.php
+++ b/tests/Controller/BrandLkControllerTest.php
@@ -37,6 +37,7 @@ class BrandLkControllerTest extends AuthenticatedWebTestCase
         yield 'brand orders'    => ['/brand/orders'];
         yield 'brand team'      => ['/brand/team'];
         yield 'brand media'     => ['/brand/media'];
+        yield 'brand links'     => ['/brand/links'];
     }
 
     // ── Access control: customer gets 403 ────────────────────────────────────


### PR DESCRIPTION
## Summary
- Владелец бренда раньше не мог указать свой сайт/соцсети — ссылки (`BrandLink`) заполнялись только enrichment'ом/агент-API. Добавлен CRUD в ЛК: `/brand/links` (список, добавление, редактирование, soft-delete).
- Реализовано строго по образцу `BrandStoreController`: `markOwnerProvenance()` через `BrandDatapoint` (provenance=owner), поиск «своей» ссылки только среди активных ссылок текущего бренда.
- Валидация: `ChoiceType` для `linkType` (website/instagram/vk/telegram/youtube/tiktok/other — фиксированный список из докблока сущности), `Assert\Url(protocols: ['http','https'])` + `Assert\Length(max: 255)` на `linkUrl` (отклоняет `javascript:`, `ftp://`, строки без схемы), лимит 8 ссылок на бренд, запрет дублей URL внутри бренда.
- Soft-delete через существующее поле `status` (трейт `Status` у `BrandLink`) — физическая строка остаётся. `Brand::getUniqueLinks()` (публичный вывод) и новый `Brand::getActiveLinks()` (ЛК) фильтруют удалённые.
- IDOR: попытка редактировать/удалить чужую ссылку → 404 (проверка владения раньше CSRF — как в `WardrobeController::resolvePhotoAction`).
- Пункт «Ссылки» добавлен в сайдбар `brand_lk/layout.html.twig`; `/brand/links` добавлен в общий guard-тест `BrandLkControllerTest::brandPathsProvider`.
- Миграция не требуется — `status`/`created_at`/`link_type`/`link_url` у `brand_link` уже существуют.

## Test plan
- [x] `BrandLinkControllerTest` (новый, 8 тестов): добавление и появление в ЛК+на публичной странице бренда; чужая ссылка → 404 при правке/удалении, данные не меняются; невалидные URL (`javascript:alert(1)`, `ftp://…`, без схемы) → 422 + `.form-error`, ничего не создаётся; дубль URL отклонён; 9-я ссылка отклонена; удаление — soft-delete (пропадает из ЛК и с публичной страницы, строка остаётся).
- [x] Полный прогон: `php -d memory_limit=512M vendor/bin/phpunit` — 417/417 зелёных (существующие тесты не сломаны).

🤖 Generated with [Claude Code](https://claude.com/claude-code)