### PR TITLE
P0-фикс: валидация загрузки логотипа бренда и фото товара

### DIFF
--- a/src/Controller/BrandLk/BrandProductController.php
+++ b/src/Controller/BrandLk/BrandProductController.php
@@ -22,6 +22,8 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\String\Slugger\SluggerInterface;
+use Symfony\Component\Validator\Constraints\Image;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 #[Route('/brand/products', name: 'brand_product')]
 class BrandProductController extends BrandDashboardController
@@ -190,6 +192,7 @@ class BrandProductController extends BrandDashboardController
         Product $product,
         Request $request,
         EntityManagerInterface $em,
+        ValidatorInterface $validator,
     ): JsonResponse {
         if (!$this->isCsrfTokenValid('brand_product_images', (string) $request->headers->get('X-CSRF-Token'))) {
             return $this->json(['error' => 'Недействительный токен'], 403);
@@ -205,13 +208,29 @@ class BrandProductController extends BrandDashboardController
 
         $isFirst  = $product->getProductImages()->isEmpty();
         $uploaded = 0;
+        $errors   = [];
 
         foreach ($files as $file) {
             if (!$file) {
                 continue;
             }
+
+            $violations = $validator->validate($file, new Image([
+                'maxSize' => '5M',
+                'mimeTypes' => ['image/jpeg', 'image/png', 'image/webp'],
+                'mimeTypesMessage' => 'Допустимы только JPEG, PNG и WebP',
+            ]));
+            if ($violations->count() > 0) {
+                $errors[] = $violations->get(0)->getMessage();
+                continue;
+            }
+
             $image = new ProductImage();
             $image->setProduct($product);
+            // slug унаследован от общего DefaultFields (nevinny/admin-core), для превью
+            // товара он не используется нигде — но колонка NOT NULL (см. миграцию
+            // Version20260524_fix_product_image_schema, DEFAULT '' на проде).
+            $image->setSlug('');
             $image->setPreviewFile($file);
             $image->setIsMain($isFirst && $uploaded === 0);
             $em->persist($image);
@@ -220,7 +239,7 @@ class BrandProductController extends BrandDashboardController
 
         $em->flush();
 
-        return $this->json(['uploaded' => $uploaded]);
+        return $this->json(['uploaded' => $uploaded, 'errors' => $errors]);
     }
 
     #[Route('/{id}/images/{imageId}/delete', name: '_image_delete', methods: ['POST'])]

--- a/src/Entity/Brand.php
+++ b/src/Entity/Brand.php
@@ -12,6 +12,7 @@ use Nevinny\AdminCoreBundle\Entity\Trait\Owner;
 use Nevinny\AdminCoreBundle\Entity\Trait\Status;
 use Nevinny\AdminCoreBundle\Enum\Statuses;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
+use Symfony\Component\Validator\Constraints as Assert;
 use Vich\UploaderBundle\Mapping\Annotation as Vich;
 use Symfony\Component\HttpFoundation\File\File;
 
@@ -36,6 +37,15 @@ class Brand
     private ?string $logo = null;
 
     #[Vich\UploadableField(mapping: 'brand_logo', fileNameProperty: 'logo')]
+    #[Assert\Image(
+        maxSize: '5M',
+        mimeTypes: ['image/jpeg', 'image/png', 'image/webp'],
+        mimeTypesMessage: 'Допустимы только форматы JPEG, PNG и WebP (SVG запрещён)',
+        maxWidth: 5000,
+        maxHeight: 5000,
+        maxWidthMessage: 'Изображение слишком широкое (максимум {{ max_width }}px)',
+        maxHeightMessage: 'Изображение слишком высокое (максимум {{ max_height }}px)',
+    )]
     private ?File $logoFile = null;
 
     /** Логотип закреплён оператором вручную → агент-пуш его не перезаписывает. */

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -12,6 +12,7 @@ use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 use Symfony\Component\Security\Core\User\EquatableInterface;
 use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Validator\Constraints as Assert;
 use Vich\UploaderBundle\Mapping\Annotation as Vich;
 use Symfony\Component\HttpFoundation\File\File;
 
@@ -55,6 +56,15 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, Equatab
     private ?string $avatar = null;
 
     #[Vich\UploadableField(mapping: 'user_avatar', fileNameProperty: 'avatar')]
+    #[Assert\Image(
+        maxSize: '5M',
+        mimeTypes: ['image/jpeg', 'image/png', 'image/webp'],
+        mimeTypesMessage: 'Допустимы только форматы JPEG, PNG и WebP (SVG запрещён)',
+        maxWidth: 5000,
+        maxHeight: 5000,
+        maxWidthMessage: 'Изображение слишком широкое (максимум {{ max_width }}px)',
+        maxHeightMessage: 'Изображение слишком высокое (максимум {{ max_height }}px)',
+    )]
     private ?File $avatarFile = null;
 
     // Telegram chat ID для уведомлений

--- a/src/Entity/WardrobeItem.php
+++ b/src/Entity/WardrobeItem.php
@@ -10,6 +10,7 @@ use Doctrine\Common\Collections\Collection;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\HttpFoundation\File\File;
+use Symfony\Component\Validator\Constraints as Assert;
 use Vich\UploaderBundle\Mapping\Annotation as Vich;
 
 #[ORM\Entity(repositoryClass: WardrobeItemRepository::class)]
@@ -188,6 +189,15 @@ class WardrobeItem
     private ?string $photo = null;
 
     #[Vich\UploadableField(mapping: 'wardrobe_item_photo', fileNameProperty: 'photo')]
+    #[Assert\Image(
+        maxSize: '10M',
+        mimeTypes: ['image/jpeg', 'image/png', 'image/webp'],
+        mimeTypesMessage: 'Разрешены только JPG, PNG и WebP.',
+        maxWidth: 5000,
+        maxHeight: 5000,
+        maxWidthMessage: 'Изображение слишком широкое (максимум {{ max_width }}px)',
+        maxHeightMessage: 'Изображение слишком высокое (максимум {{ max_height }}px)',
+    )]
     private ?File $photoFile = null;
 
     /** @var Collection<int, WardrobeItemPhoto> */

--- a/templates/account/profile.html.twig
+++ b/templates/account/profile.html.twig
@@ -27,6 +27,7 @@
                 <div>
                     <div class="mb-1 text-sm font-semibold">Фото профиля</div>
                     {{ form_widget(form.avatarFile, {'attr': {'class': 'text-sm'}}) }}
+                    <div class="form-error mt-1 text-sm text-red-600">{{ form_errors(form.avatarFile) }}</div>
                     <div class="text-xs text-gray-400">JPG, PNG — не более 2 МБ</div>
                 </div>
             </div>

--- a/templates/brand_lk/profile.html.twig
+++ b/templates/brand_lk/profile.html.twig
@@ -44,6 +44,7 @@
                 <span class="{{ section_class }} border-t border-gray-100 pt-5">Логотип</span>
                 <div class="mb-6 text-sm">
                     {{ form_widget(form.logoFile) }}
+                    <div class="form-error mt-1 text-sm text-red-600">{{ form_errors(form.logoFile) }}</div>
                 </div>
 
                 {# Контакты #}

--- a/tests/Controller/BrandUploadValidationTest.php
+++ b/tests/Controller/BrandUploadValidationTest.php
@@ -1,0 +1,252 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Controller;
+
+use App\Entity\Brand;
+use App\Entity\Product;
+use App\Entity\ProductImage;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Symfony\Component\HttpFoundation\Request;
+use Vich\UploaderBundle\Storage\StorageInterface;
+
+/**
+ * P0-регресс: логотип бренда (VichImageType без constraints, Brand::$logoFile без
+ * единого Assert) и фото товара (ручной цикл в BrandProductController без валидации)
+ * принимали любой файл и отдавали его с домена wearbase.ru — можно было залить SVG
+ * со <script> (stored XSS на origin, угон сессии /admin).
+ *
+ * Фикс: Assert\Image на Brand::$logoFile (форма валидирует data_class-объект
+ * автоматически при submit) + ручная Image-валидация в BrandProductController::uploadImages
+ * по образцу уже существующего BrandMediaController::upload().
+ *
+ * Run with: php bin/phpunit tests/Controller/BrandUploadValidationTest.php
+ */
+class BrandUploadValidationTest extends AuthenticatedWebTestCase
+{
+    private const PROFILE_FORM_NAME = 'brand_profile_form';
+
+    /** @var string[] absolute paths of files created by tests, cleaned up in tearDown */
+    private array $tmpFiles = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->skipIfNoDatabase();
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->tmpFiles as $path) {
+            if (is_file($path)) {
+                @unlink($path);
+            }
+        }
+        $this->tmpFiles = [];
+        parent::tearDown();
+    }
+
+    // ── Логотип бренда: /brand/profile ─────────────────────────────────────
+
+    public function testSvgLogoIsRejected(): void
+    {
+        $client = static::createClient();
+        [, $brand] = $this->loginAsBrandOwnerWithBrand($client);
+        $brandId = $brand->getId();
+
+        $crawler = $client->request('GET', '/brand/profile');
+        $form = $crawler->filter('form')->form();
+        $form[self::PROFILE_FORM_NAME . '[logoFile][file]']->upload($this->makeSvgFile());
+
+        $client->submit($form);
+
+        // Форма невалидна → Symfony AbstractController::render() автоматически возвращает
+        // 422 для submitted-but-invalid формы (см. AbstractController::render()), а не
+        // редирект на успех.
+        $this->assertResponseStatusCodeSame(422);
+
+        $this->assertBrandLogoUnchanged($brandId);
+    }
+
+    public function testPngWithSvgContentAsLogoIsRejected(): void
+    {
+        $client = static::createClient();
+        [, $brand] = $this->loginAsBrandOwnerWithBrand($client);
+        $brandId = $brand->getId();
+
+        $crawler = $client->request('GET', '/brand/profile');
+        $form = $crawler->filter('form')->form();
+        // Реальный контент — SVG/HTML, расширение обманчиво .png: детект должен идти по содержимому.
+        $form[self::PROFILE_FORM_NAME . '[logoFile][file]']->upload($this->makeSvgContentWithPngExtension());
+
+        $client->submit($form);
+
+        $this->assertResponseStatusCodeSame(422);
+        $this->assertBrandLogoUnchanged($brandId);
+    }
+
+    public function testValidPngLogoIsAccepted(): void
+    {
+        $client = static::createClient();
+        [, $brand] = $this->loginAsBrandOwnerWithBrand($client);
+        $brandId = $brand->getId();
+
+        $crawler = $client->request('GET', '/brand/profile');
+        $form = $crawler->filter('form')->form();
+        $form[self::PROFILE_FORM_NAME . '[logoFile][file]']->upload($this->makeValidPng());
+
+        $client->submit($form);
+
+        $this->assertResponseRedirects('/brand/profile');
+
+        /** @var EntityManagerInterface $em */
+        $em = static::getContainer()->get('doctrine.orm.entity_manager');
+        $em->clear();
+        /** @var Brand $reloaded */
+        $reloaded = $em->getRepository(Brand::class)->find($brandId);
+        $this->assertNotNull($reloaded->getLogo(), 'Валидный PNG должен был сохраниться как логотип');
+
+        /** @var StorageInterface $storage */
+        $storage = static::getContainer()->get(StorageInterface::class);
+        $this->tmpFiles[] = $storage->resolvePath($reloaded, 'logoFile');
+    }
+
+    private function assertBrandLogoUnchanged(int $brandId): void
+    {
+        /** @var EntityManagerInterface $em */
+        $em = static::getContainer()->get('doctrine.orm.entity_manager');
+        $em->clear();
+        /** @var Brand $reloaded */
+        $reloaded = $em->getRepository(Brand::class)->find($brandId);
+        $this->assertNull($reloaded->getLogo(), 'Невалидный файл не должен был сохраниться как логотип');
+    }
+
+    // ── Фото товара: /brand/products/{id}/images/upload ─────────────────────
+
+    public function testSvgProductImageIsRejected(): void
+    {
+        $client = static::createClient();
+        [, $brand] = $this->loginAsBrandOwnerWithBrand($client);
+        $product = $this->makeProduct($brand);
+
+        $client->request('GET', '/brand/products/' . $product->getId() . '/images');
+        $token = $this->forceCsrfToken($client->getRequest(), 'brand_product_images');
+
+        $svg = new UploadedFile($this->makeSvgFile(), 'evil.svg', 'image/svg+xml', null, true);
+
+        $client->request(
+            'POST',
+            '/brand/products/' . $product->getId() . '/images/upload',
+            [],
+            ['images' => [$svg]],
+            ['HTTP_X_CSRF_TOKEN' => $token],
+        );
+
+        $this->assertResponseIsSuccessful();
+        $data = json_decode($client->getResponse()->getContent(), true);
+        $this->assertSame(0, $data['uploaded']);
+        $this->assertCount(1, $data['errors']);
+
+        /** @var EntityManagerInterface $em */
+        $em = static::getContainer()->get('doctrine.orm.entity_manager');
+        $this->assertCount(0, $em->getRepository(ProductImage::class)->findBy(['product' => $product]));
+    }
+
+    public function testValidPngProductImageIsAccepted(): void
+    {
+        $client = static::createClient();
+        [, $brand] = $this->loginAsBrandOwnerWithBrand($client);
+        $product = $this->makeProduct($brand);
+
+        $client->request('GET', '/brand/products/' . $product->getId() . '/images');
+        $token = $this->forceCsrfToken($client->getRequest(), 'brand_product_images');
+
+        $png = new UploadedFile($this->makeValidPng(), 'photo.png', 'image/png', null, true);
+
+        $client->request(
+            'POST',
+            '/brand/products/' . $product->getId() . '/images/upload',
+            [],
+            ['images' => [$png]],
+            ['HTTP_X_CSRF_TOKEN' => $token],
+        );
+
+        $this->assertResponseIsSuccessful();
+        $data = json_decode($client->getResponse()->getContent(), true);
+        $this->assertSame(1, $data['uploaded']);
+        $this->assertSame([], $data['errors']);
+
+        /** @var EntityManagerInterface $em */
+        $em = static::getContainer()->get('doctrine.orm.entity_manager');
+        $images = $em->getRepository(ProductImage::class)->findBy(['product' => $product]);
+        $this->assertCount(1, $images);
+
+        /** @var StorageInterface $storage */
+        $storage = static::getContainer()->get(StorageInterface::class);
+        $this->tmpFiles[] = $storage->resolvePath($images[0], 'previewFile');
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────
+
+    private function makeProduct(Brand $brand): Product
+    {
+        /** @var EntityManagerInterface $em */
+        $em = static::getContainer()->get('doctrine.orm.entity_manager');
+
+        $product = new Product();
+        $product->setBrand($brand);
+        $product->setTitle('Test product ' . uniqid());
+        $product->setSlug('test-product-' . uniqid());
+        $em->persist($product);
+        $em->flush();
+
+        return $product;
+    }
+
+    private function makeValidPng(): string
+    {
+        $path = sys_get_temp_dir() . '/brand_upload_test_' . uniqid() . '.png';
+        $im = imagecreatetruecolor(4, 4);
+        imagepng($im, $path);
+        imagedestroy($im);
+        $this->tmpFiles[] = $path;
+
+        return $path;
+    }
+
+    private function makeSvgFile(): string
+    {
+        $path = sys_get_temp_dir() . '/brand_upload_test_' . uniqid() . '.svg';
+        file_put_contents($path, '<svg xmlns="http://www.w3.org/2000/svg"><script>alert(document.cookie)</script></svg>');
+        $this->tmpFiles[] = $path;
+
+        return $path;
+    }
+
+    private function makeSvgContentWithPngExtension(): string
+    {
+        $path = sys_get_temp_dir() . '/brand_upload_test_' . uniqid() . '.png';
+        file_put_contents($path, '<svg xmlns="http://www.w3.org/2000/svg"><script>alert(document.cookie)</script></svg>');
+        $this->tmpFiles[] = $path;
+
+        return $path;
+    }
+
+    /**
+     * Форсирует CSRF-токен для JSON-эндпоинта (см. аналогичный хелпер в
+     * WardrobeIngestControllerTest) — токен генерируется в сессии последнего
+     * реального запроса клиента, иначе не совпадёт с тем, что проверит контроллер.
+     */
+    private function forceCsrfToken(Request $lastRequest, string $tokenId): string
+    {
+        $requestStack = static::getContainer()->get('request_stack');
+        $requestStack->push($lastRequest);
+        $token = static::getContainer()->get('security.csrf.token_manager')->getToken($tokenId)->getValue();
+        $requestStack->pop();
+        $lastRequest->getSession()->save();
+
+        return $token;
+    }
+}


### PR DESCRIPTION
## Проблема

Владелец бренда через ЛК мог загрузить файл в webroot без валидации типа/содержимого:

1. `BrandProfileFormType::logoFile` (`VichImageType`) — без `constraints`; `Brand::$logoFile` — без единого `Assert`.
2. `BrandProductController::uploadImages` (фото товара) — цикл `setPreviewFile($file)` вообще без валидации.

Файлы отдаются с домена wearbase.ru → SVG со `<script>` = stored XSS на origin → угон сессии `/admin`. Проект уже хранит реальные SVG-логотипы, т.е. вектор рабочий.

Заодно нашлись ещё два поля той же природы вне первоначального скоупа BrandLk (пойманы тем же grep по `src/Form/**`): `User::$avatarFile` (аккаунт) и `WardrobeItem::$photoFile` (гардероб) — тоже без валидации, тоже исправлены тем же способом.

## Фикс

- **`Assert\Image`** на `Brand::$logoFile`, `User::$avatarFile`, `WardrobeItem::$photoFile` — `maxSize: 5M`/`10M`, `mimeTypes: [jpeg, png, webp]` (SVG исключён — не входит в список), `maxWidth/maxHeight: 5000px` (анти-decompression-bomb). Валидируется автоматически при сабмите формы (Symfony валидирует data_class объект по умолчанию).
  - Технический нюанс: `VichImageType`/`VichFileType` — корневые form-типы без `getParent()`, поэтому НЕ поддерживают опцию `constraints` на самом поле (проверено эмпирически и по исходникам vendor) — валидация возможна только через `Assert` на свойстве сущности.
- **Ручная `Image`-валидация** в `BrandProductController::uploadImages` — по образцу уже существующего `BrandMediaController::upload()` (эталон, не тронут), но с доработкой: невалидный файл пропускается (`continue`), остальные валидные из той же пачки обрабатываются, ответ не 500.
- Определение mime — по реальному содержимому (`File::getMimeType()` через finfo), не по расширению — покрыто тестом `evil.png` с SVG-содержимым внутри.
- `form_errors` для `logoFile`/`avatarFile` в шаблонах (были без обратной связи пользователю при отклонении).
- Сопутствующий минорный фикс: `ProductImage::slug` (NOT NULL, унаследовано от `DefaultFields`) не проставлялся в `uploadImages` — вскрылось при написании теста happy-path (в проде терпимо благодаря `DEFAULT ''` в миграции, но правильнее не полагаться на это).

## Не проверял/не трогал (по скоупу)

- `src/Controller/Account/WardrobeIngestController.php` — уже валидирует корректно (эталон для моего фикса).
- `src/Service/Wardrobe/WardrobeRemotePhotoFetcher.php` — уже валидирует (allowlist домена + mime по содержимому).
- `src/Service/Telegram/WardrobeDialogService.php::commitDraft` — фото из Telegram (`photo_file_id`) сохраняется без allowlist mime перед `setPhotoFile()`; отдельный канал (не веб-форма), риск ниже (Telegram сам конвертирует `photo` в JPEG на своей стороне), но стоит отдельного тикета.
- `src/Controller/Admin/AuthorCrudController.php` — EasyAdmin `ImageField`, админка, вне скоупа.
- `src/Controller/Api/BrandIngestController.php` — докблок упоминает `logo`/`content_base64`, но в коде не реализовано — не актуально.

## Тесты

Новый `tests/Controller/BrandUploadValidationTest.php` (5 тестов): SVG-логотип отклонён, PNG с SVG-содержимым внутри отклонён, валидный PNG-логотип проходит; то же для фото товара (SVG отклонён, PNG проходит).

Полный прогон: `431 tests, 1362 assertions, 1 failure` — единственный fail (`RagBrandPanelTest`, `@hotwired/stimulus` vendor asset missing) пред-существующий и не связан с этим PR (подтверждено прогоном той же версии теста на `main` без моих изменений).

## Test plan
- [x] `php -d memory_limit=512M bin/phpunit tests/Controller/BrandUploadValidationTest.php` — 5/5 зелёных
- [x] Полный набор тестов — без новых регрессов