### PR TITLE
feat(moderation): бэкафилл очереди премодерации для self-reg брендов

### DIFF
--- a/src/Command/ModerationBackfillCommand.php
+++ b/src/Command/ModerationBackfillCommand.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Command;
+
+use App\Entity\Brand;
+use App\Entity\BrandModeration;
+use App\Entity\BrandUser;
+use App\Repository\BrandModerationRepository;
+use App\Repository\BrandUserRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Nevinny\AdminCoreBundle\Enum\Statuses;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * Подчистка очереди премодерации (BrandModeration, PR #69) для самрег-брендов, заведённых
+ * ДО того, как RegisterController стал создавать строку `queued` при регистрации.
+ *
+ * Штатный путь — хук в RegisterController: он ставит новый бренд в очередь сразу при
+ * self-register. Эта команда не заменяет хук, а разово (или по мере обнаружения потерянных
+ * заявок) находит бренды с владельцем (BrandUser::ROLE_OWNER — признак self-register/claim,
+ * у каталожных брендов из импортов такой строки нет), у которых `brand_moderation` пуста, и
+ * дописывает недостающую строку задним числом.
+ *
+ * Идемпотентна: бренд с уже существующей строкой в brand_moderation пропускается.
+ * Удалённые бренды (Statuses::Deleted) не обрабатываются.
+ *
+ *   php bin/console app:brand:moderation-backfill --dry-run   # показать, что будет создано
+ *   php bin/console app:brand:moderation-backfill              # применить
+ *   php bin/console app:brand:moderation-backfill --limit=500
+ */
+#[AsCommand(
+    name: 'app:brand:moderation-backfill',
+    description: 'Задним числом ставит self-register бренды без строки в brand_moderation в очередь премодерации',
+)]
+class ModerationBackfillCommand extends Command
+{
+    public function __construct(
+        private readonly BrandUserRepository $brandUserRepo,
+        private readonly BrandModerationRepository $moderationRepo,
+        private readonly EntityManagerInterface $em,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Только показать, ничего не писать')
+            ->addOption('limit', null, InputOption::VALUE_REQUIRED, 'Сколько owner-брендов обработать за прогон', 200);
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io     = new SymfonyStyle($input, $output);
+        $dryRun = (bool) $input->getOption('dry-run');
+        $limit  = (int) $input->getOption('limit');
+
+        /** @var BrandUser[] $owners */
+        $owners = $this->brandUserRepo->findBy(['role' => BrandUser::ROLE_OWNER]);
+
+        /** @var array<int,Brand> $brands */
+        $brands = [];
+        foreach ($owners as $owner) {
+            $brand = $owner->getBrand();
+            if ($brand !== null) {
+                $brands[$brand->getId()] = $brand;
+            }
+        }
+        ksort($brands);
+        $brands = array_slice($brands, 0, $limit, true);
+
+        $rows      = [];
+        $created   = 0;
+        $existing  = 0;
+        $skipped   = 0;
+        foreach ($brands as $brand) {
+            $status = $brand->getStatus();
+
+            if ($status === Statuses::Deleted) {
+                $rows[] = [$brand->getId(), $brand->getTitle(), $status->value, 'пропущен (удалён)'];
+                $skipped++;
+                continue;
+            }
+
+            if ($this->moderationRepo->findOneByBrand($brand) !== null) {
+                $rows[] = [$brand->getId(), $brand->getTitle(), $status->value, 'уже была'];
+                $existing++;
+                continue;
+            }
+
+            $rows[] = [$brand->getId(), $brand->getTitle(), $status->value, $dryRun ? '[dry-run] будет создана' : 'создана строка'];
+            $created++;
+
+            if (!$dryRun) {
+                $moderation = new BrandModeration();
+                $moderation->setBrand($brand);
+                $moderation->setSource(BrandModeration::SOURCE_SELF_REGISTER);
+                $this->em->persist($moderation);
+            }
+        }
+
+        if (!$dryRun && $created > 0) {
+            $this->em->flush();
+        }
+
+        $io->table(['ID', 'Бренд', 'Статус', 'Результат'], $rows);
+        $io->success(sprintf(
+            '%s: %d из %d owner-брендов (уже была: %d, пропущено: %d)',
+            $dryRun ? 'Будет создано' : 'Создано',
+            $created,
+            count($brands),
+            $existing,
+            $skipped,
+        ));
+
+        return Command::SUCCESS;
+    }
+}

--- a/tests/Command/ModerationBackfillCommandTest.php
+++ b/tests/Command/ModerationBackfillCommandTest.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Command;
+
+use App\Entity\Brand;
+use App\Entity\BrandModeration;
+use App\Entity\BrandUser;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Nevinny\AdminCoreBundle\Enum\Statuses;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * app:brand:moderation-backfill — подчистка исторических self-register брендов, заведённых
+ * до того, как RegisterController стал класть строку BrandModeration при регистрации (PR #69).
+ */
+class ModerationBackfillCommandTest extends KernelTestCase
+{
+    private EntityManagerInterface $em;
+    private CommandTester $tester;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $this->em = self::getContainer()->get(EntityManagerInterface::class);
+        $this->em->beginTransaction();
+        $this->tester = new CommandTester((new Application(self::$kernel))->find('app:brand:moderation-backfill'));
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->em->getConnection()->isTransactionActive()) {
+            $this->em->rollback();
+        }
+        parent::tearDown();
+    }
+
+    public function testOwnerBrandWithoutRowGetsQueued(): void
+    {
+        $brand = $this->ownerBrand();
+
+        $this->tester->execute([]);
+
+        $this->tester->assertCommandIsSuccessful();
+        $moderation = $this->em->getRepository(BrandModeration::class)->findOneBy(['brand' => $brand]);
+        $this->assertNotNull($moderation, 'Строка очереди должна быть создана');
+        $this->assertSame(BrandModeration::STATUS_QUEUED, $moderation->getStatus());
+        $this->assertSame(BrandModeration::SOURCE_SELF_REGISTER, $moderation->getSource());
+    }
+
+    public function testSecondRunIsIdempotent(): void
+    {
+        $brand = $this->ownerBrand();
+
+        $this->tester->execute([]);
+        $this->tester->execute([]);
+
+        $this->tester->assertCommandIsSuccessful();
+        $this->assertCount(
+            1,
+            $this->em->getRepository(BrandModeration::class)->findBy(['brand' => $brand]),
+            'Повторный прогон не должен плодить строки',
+        );
+    }
+
+    public function testCatalogBrandWithoutOwnerIsSkipped(): void
+    {
+        $brand = (new Brand())->setTitle('Каталожный бренд ' . uniqid());
+        $brand->setSlug('catalog-' . uniqid());
+        $this->em->persist($brand);
+        $this->em->flush();
+
+        $this->tester->execute([]);
+
+        $this->tester->assertCommandIsSuccessful();
+        $this->assertNull(
+            $this->em->getRepository(BrandModeration::class)->findOneBy(['brand' => $brand]),
+            'У бренда без владельца строки очереди быть не должно',
+        );
+    }
+
+    public function testDeletedBrandIsSkipped(): void
+    {
+        $brand = $this->ownerBrand();
+        $brand->setStatus(Statuses::Deleted);
+        $this->em->flush();
+
+        $this->tester->execute([]);
+
+        $this->tester->assertCommandIsSuccessful();
+        $this->assertNull(
+            $this->em->getRepository(BrandModeration::class)->findOneBy(['brand' => $brand]),
+            'Удалённый бренд не должен попадать в очередь',
+        );
+    }
+
+    public function testDryRunWritesNothing(): void
+    {
+        $brand = $this->ownerBrand();
+
+        $this->tester->execute(['--dry-run' => true]);
+
+        $this->tester->assertCommandIsSuccessful();
+        $this->assertStringContainsString('dry-run', $this->tester->getDisplay());
+        $this->assertNull(
+            $this->em->getRepository(BrandModeration::class)->findOneBy(['brand' => $brand]),
+            'dry-run не должен ничего писать',
+        );
+    }
+
+    /** Создаёт бренд с владельцем (self-register), как это делает RegisterController. */
+    private function ownerBrand(): Brand
+    {
+        $user = new User();
+        $user->setEmail('owner-' . uniqid() . '@example.com');
+        $user->setPassword('hashed');
+        $user->setRoles(['ROLE_BRAND_MANAGER']);
+        $this->em->persist($user);
+
+        $brand = new Brand();
+        $brand->setTitle('Самрег бренд ' . uniqid());
+        $brand->setSlug('self-reg-' . uniqid());
+        $brand->setStatus(Statuses::New);
+        $this->em->persist($brand);
+
+        $brandUser = new BrandUser();
+        $brandUser->setUser($user);
+        $brandUser->setBrand($brand);
+        $brandUser->setRole(BrandUser::ROLE_OWNER);
+        $this->em->persist($brandUser);
+
+        $this->em->flush();
+
+        return $brand;
+    }
+}


### PR DESCRIPTION
## Что
`app:brand:moderation-backfill` — разовая (и по мере надобности повторяемая) команда,
которая находит owner-бренды (self-register/claim через `BrandUser::ROLE_OWNER`) без
строки в `brand_moderation` и ставит их в очередь `queued`/`self_register`.

## Зачем
Хук в `RegisterController` (PR #69) кладёт строку очереди только на новых регистрациях.
На проде уже есть 2 исторических самрег-бренда без строки — `app:brand:moderate-tick`
их не видит, потому что очередь строго `brand_moderation`.

## Поведение
- Идемпотентна: бренд с уже существующей строкой пропускается.
- Удалённые бренды (`Statuses::Deleted`) пропускаются.
- `--dry-run` — только печать, ничего не пишет.
- `--limit=N` (по умолчанию 200) — сколько owner-брендов обработать за прогон.
- Таблица по каждому бренду + итоговые счётчики.

## Прод
```
php bin/console app:brand:moderation-backfill --dry-run
php bin/console app:brand:moderation-backfill
```

## Тесты
`tests/Command/ModerationBackfillCommandTest.php`: создание строки, идемпотентность
повторного прогона, пропуск каталожного бренда без владельца, пропуск удалённого
бренда, `--dry-run` ничего не пишет.

## Test plan
- [x] `php -d memory_limit=512M bin/phpunit` — 436 тестов зелёные (5 новых)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>