### PR TITLE
fix(moderation): no_trace не даёт reject + поиск сайта по контактам заявки

### DIFF
--- a/src/Command/ModerateTickCommand.php
+++ b/src/Command/ModerateTickCommand.php
@@ -13,6 +13,7 @@ use App\Service\Discovery\DiscoveredUrl;
 use App\Service\Moderation\ApplicationMatcher;
 use App\Service\NearDuplicateDetector;
 use App\Service\WebScraperService;
+use App\Service\YandexSearchClient;
 use App\Service\YandexSearchMeter;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -61,6 +62,7 @@ class ModerateTickCommand extends Command
         private readonly ApplicationMatcher $matcher,
         private readonly NearDuplicateDetector $dup,
         private readonly YandexSearchMeter $yandexMeter,
+        private readonly YandexSearchClient $yandex,
         private readonly AdminNotifier $notifier,
         private readonly BrandActionSigner $actionSigner,
         private readonly EntityManagerInterface $em,
@@ -174,7 +176,24 @@ class ModerateTickCommand extends Command
             }
         }
 
-        [$pages, $officialDomain, $siteFlags] = $this->collectPages($ownSite);
+        // Угаданный из слага домен ({slug}.ru/.com — самый слабый T1-сигнал discoverTiered)
+        // не факт о бренде, а наша догадка: если он не отвечает, это не site_unreachable.
+        $guessedSlugUrls = $slug !== '' ? ["https://{$slug}.ru", "https://{$slug}.com"] : [];
+        $isSlugGuess = $ownSite !== null && in_array(rtrim($ownSite->url, '/'), $guessedSlugUrls, true);
+
+        // Bug 2: discoverTiered() строит кандидатов из названия/слага — для патологических
+        // названий (мало значащих символов + пунктуация, кейс «Русский бренд АХ!») либо
+        // ничего не находит, либо угаданный домен не отвечает. Пробуем найти сайт по
+        // контактам ИЗ ЗАЯВКИ (см. discoverByContacts) прежде чем сдаваться.
+        if ($ownSite === null || !$ownSite->live) {
+            $byContact = $this->discoverByContacts($item);
+            if ($byContact !== null) {
+                $ownSite = $byContact;
+                $isSlugGuess = false; // найден поиском, не нашей догадкой
+            }
+        }
+
+        [$pages, $officialDomain, $siteFlags] = $this->collectPages($ownSite, $isSlugGuess);
 
         $match = $this->matcher->evaluate(
             ['title' => $title, 'email' => $item['email'] ?? null, 'phone' => $item['phone'] ?? null, 'address' => $item['address'] ?? null],
@@ -187,7 +206,7 @@ class ModerateTickCommand extends Command
         $redFlags = array_merge($siteFlags, $checklistFlags, $this->duplicateFlags($title, $ownSite));
 
         [$nicheStatus, $originStatus, $note] = $this->classifyOnMacIfMirrored($slug);
-        $verdict = $this->decideVerdict($match, $redFlags);
+        $verdict = $this->decideVerdict($match, $redFlags, $nicheStatus, $originStatus);
         $summary = $this->buildSummary($match, $missing, $redFlags, $note);
 
         $io->text(sprintf('  identity=%s control=%s verdict=%s', $match['identity_match'], $match['control_proof'], $verdict));
@@ -215,8 +234,12 @@ class ModerateTickCommand extends Command
         }
     }
 
-    /** @return array{0:array<int,array{url:string,html:string}>,1:?string,2:string[]} */
-    private function collectPages(?DiscoveredUrl $ownSite): array
+    /**
+     * @param bool $isSlugGuess true — $ownSite->url это {slug}.ru/.com, угаданный нами
+     *        (не факт о бренде): недоступность такого домена не флагуем (Bug 2)
+     * @return array{0:array<int,array{url:string,html:string}>,1:?string,2:string[]}
+     */
+    private function collectPages(?DiscoveredUrl $ownSite, bool $isSlugGuess = false): array
     {
         if ($ownSite === null) {
             return [[], null, []];
@@ -224,7 +247,7 @@ class ModerateTickCommand extends Command
 
         $main = $this->scraper->fetch($ownSite->url);
         if ($main === null || $main['html'] === '') {
-            return [[], null, ['site_unreachable:' . $ownSite->url]];
+            return [[], null, $isSlugGuess ? [] : ['site_unreachable:' . $ownSite->url]];
         }
 
         $pages = [['url' => $main['url'], 'html' => $main['html']]];
@@ -249,6 +272,61 @@ class ModerateTickCommand extends Command
         $host = parse_url($url, PHP_URL_HOST);
 
         return is_string($host) ? strtolower(preg_replace('/^www\./', '', $host)) : null;
+    }
+
+    /**
+     * Bug 2: discoverTiered() строит кандидатов из названия/слага — патологические названия
+     * (мало значащих символов, кейс «Русский бренд АХ!») не дают ничего живого. Ищем сайт по
+     * КОНТАКТАМ ИЗ ЗАЯВКИ (телефон в нескольких форматах + email) через тот же Yandex Search
+     * API, что и BrandSourceFinder (квота — через его собственный YandexSearchMeter внутри
+     * YandexSearchClient::search()). Кандидата подтверждаем ApplicationMatcher — телефон/email
+     * реально на странице, а не просто совпал в выдаче.
+     *
+     * @param array<string,mixed> $item элемент очереди (phone/email заявителя)
+     */
+    private function discoverByContacts(array $item): ?DiscoveredUrl
+    {
+        $phone = trim((string) ($item['phone'] ?? ''));
+        $email = trim((string) ($item['email'] ?? ''));
+
+        $queries = [];
+        if ($phone !== '') {
+            $ten = $this->matcher->normalizePhone($phone);
+            if ($ten !== '') {
+                $queries[] = '+7' . $ten;
+                $queries[] = '8' . $ten;
+                $queries[] = $ten;
+            }
+        }
+        if ($email !== '') {
+            $queries[] = $email;
+        }
+
+        foreach ($queries as $q) {
+            foreach ($this->yandex->search($q, 5) as $r) {
+                $url = trim((string) ($r['url'] ?? ''));
+                if ($url === '') {
+                    continue;
+                }
+                $page = $this->scraper->fetch($url);
+                if ($page === null || $page['html'] === '') {
+                    continue;
+                }
+                // Только против самих контактов заявки (title намеренно не передаём —
+                // здесь нужно доказать identity через phone/email, не через совпадение имени).
+                $confirm = $this->matcher->evaluate(
+                    ['phone' => $phone, 'email' => $email],
+                    [['url' => $page['url'], 'html' => $page['html']]],
+                    $this->hostOf($url),
+                    null,
+                );
+                if ($confirm['identity_match'] !== 'unconfirmed') {
+                    return new DiscoveredUrl($page['url'], BrandSourceUrl::TYPE_OWN_SITE, 1, 0.9, true);
+                }
+            }
+        }
+
+        return null;
     }
 
     /** @return array{0:string[],1:string[]} [missing, red_flags] */
@@ -348,13 +426,25 @@ class ModerateTickCommand extends Command
         return [$brand->getNicheStatus(), $brand->getOriginStatus(), 'ниша/происхождение определены по зеркалированной копии на Mac'];
     }
 
-    /** @param array{identity_match:string,control_proof:string,evidence:mixed} $match @param string[] $redFlags */
-    private function decideVerdict(array $match, array $redFlags): string
+    /**
+     * Маппинг вердикта — docs/brand_self_service.md §3 (таблица авто-решений).
+     * `reject` допустим ТОЛЬКО при niche_status='off' или origin_status foreign/unknown —
+     * это единственный автоматический ОТКАЗ настоящему бренду, поэтому гейт строгий.
+     * Отсутствие цифрового следа (identity_match='no_trace') — НЕ повод отклонять: молодой
+     * бренд без сайта — нормальное явление, а no_trace может значить лишь то, что мы плохо
+     * искали (Bug 2). В MVP отдельного статуса awaiting_facts нет — no_trace, как и любой
+     * неподтверждённый/слабый identity_match или красный флаг, уходит в `request_changes`
+     * (дубль/red_flags — по сути «решает человек», в MVP это тот же request_changes без
+     * авто-действия дальше).
+     *
+     * @param array{identity_match:string,control_proof:string,evidence:mixed} $match @param string[] $redFlags
+     */
+    private function decideVerdict(array $match, array $redFlags, ?string $nicheStatus, ?string $originStatus): string
     {
-        if (in_array($match['identity_match'], ['no_trace', 'unconfirmed'], true)) {
+        if ($nicheStatus === 'off' || in_array($originStatus, ['foreign', 'unknown'], true)) {
             return 'reject';
         }
-        if ($redFlags !== [] || $match['identity_match'] === 'weak') {
+        if ($redFlags !== [] || $match['identity_match'] !== 'confirmed') {
             return 'request_changes';
         }
 
@@ -364,6 +454,10 @@ class ModerateTickCommand extends Command
     /** @param string[] $missing @param string[] $redFlags */
     private function buildSummary(array $match, array $missing, array $redFlags, string $note): string
     {
+        if ($match['identity_match'] === 'no_trace') {
+            $note = trim('нужна ссылка на сайт/соцсеть — кандидата не нашли. ' . $note);
+        }
+
         return sprintf(
             'identity=%s control=%s | missing: %s | red_flags: %s | %s',
             $match['identity_match'],

--- a/tests/Command/ModerateTickCommandTest.php
+++ b/tests/Command/ModerateTickCommandTest.php
@@ -1,0 +1,181 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Command;
+
+use App\Command\ModerateTickCommand;
+use App\Notification\AdminNotifier;
+use App\Service\BrandActionSigner;
+use App\Service\BrandSourceFinder;
+use App\Service\Moderation\ApplicationMatcher;
+use App\Service\NearDuplicateDetector;
+use App\Service\WebScraperService;
+use App\Service\YandexSearchClient;
+use App\Service\YandexSearchMeter;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * Юнит-тесты на два дефекта первого живого прогона `app:brand:moderate-tick --id=3673`
+ * (реальный самрег-бренд «Русский бренд АХ!», ahsilk.ru):
+ *
+ *  Bug 1 — decideVerdict() отклонял ("reject") настоящий бренд из-за identity_match=no_trace/
+ *          unconfirmed, хотя по docs/brand_self_service.md §3 автоотказ допустим ТОЛЬКО
+ *          при niche_status=off либо origin_status foreign/unknown.
+ *  Bug 2 — сайт не находился, потому что discoverTiered() угадывает домен из слага/названия
+ *          (провал для патологических названий), хотя элементарно находится по контактам
+ *          заявки (телефон/email).
+ *
+ * Сеть не дёргаем: YandexSearchClient и WebScraperService — моки. ApplicationMatcher — настоящий
+ * (детерминированный, без сети — как и в ApplicationMatcherTest), чтобы discoverByContacts()
+ * реально прогонял ту же логику подтверждения, что и боевой путь.
+ */
+class ModerateTickCommandTest extends TestCase
+{
+    private function makeCommand(
+        ?YandexSearchClient $yandex = null,
+        ?WebScraperService $scraper = null,
+    ): ModerateTickCommand {
+        return new ModerateTickCommand(
+            $this->createMock(HttpClientInterface::class),
+            $this->createMock(BrandSourceFinder::class),
+            $scraper ?? $this->createMock(WebScraperService::class),
+            new ApplicationMatcher(),
+            $this->createMock(NearDuplicateDetector::class),
+            $this->createMock(YandexSearchMeter::class),
+            $yandex ?? $this->createMock(YandexSearchClient::class),
+            $this->createMock(AdminNotifier::class),
+            $this->createMock(BrandActionSigner::class),
+            $this->createMock(EntityManagerInterface::class),
+            'https://example.test',
+            'token',
+            'secret',
+        );
+    }
+
+    private function invoke(ModerateTickCommand $command, string $method, array $args): mixed
+    {
+        return (new \ReflectionMethod($command, $method))->invoke($command, ...$args);
+    }
+
+    // ── Bug 1: маппинг вердикта — docs/brand_self_service.md §3 ─────────────────
+
+    #[DataProvider('verdictMatrix')]
+    public function testVerdictMapping(string $identity, ?string $niche, ?string $origin, array $redFlags, string $expected): void
+    {
+        $command = $this->makeCommand();
+        $match   = ['identity_match' => $identity, 'control_proof' => 'unconfirmed', 'evidence' => []];
+
+        $this->assertSame($expected, $this->invoke($command, 'decideVerdict', [$match, $redFlags, $niche, $origin]));
+    }
+
+    public static function verdictMatrix(): iterable
+    {
+        // Кейс «АХ!»: сайт не найден (no_trace), ниша/происхождение не зеркалированы на Mac
+        // (null — обычное дело для self-reg брендов, см. classifyOnMacIfMirrored) — это НЕ
+        // должно быть автоотказом настоящему бренду.
+        yield 'no_trace + null niche/origin -> request_changes'      => ['no_trace', null, null, [], 'request_changes'];
+        yield 'unconfirmed + null niche/origin -> request_changes'   => ['unconfirmed', null, null, [], 'request_changes'];
+        yield 'weak + null niche/origin -> request_changes'          => ['weak', null, null, [], 'request_changes'];
+        yield 'confirmed + no flags -> publish'                       => ['confirmed', null, null, [], 'publish'];
+        yield 'confirmed + red flags -> request_changes (человек)'   => ['confirmed', null, null, ['no_links'], 'request_changes'];
+        yield 'confirmed + niche off -> reject (гейт важнее identity)' => ['confirmed', 'off', null, [], 'reject'];
+        yield 'no_trace + niche off -> reject (гейт важнее no_trace)'  => ['no_trace', 'off', null, [], 'reject'];
+        yield 'no_trace + origin foreign -> reject'                   => ['no_trace', null, 'foreign', [], 'reject'];
+        yield 'no_trace + origin unknown -> reject'                   => ['no_trace', null, 'unknown', [], 'reject'];
+        yield 'confirmed + niche in + origin ru -> publish'           => ['confirmed', 'in', 'ru', [], 'publish'];
+    }
+
+    /**
+     * Инвариант из задачи: `no_trace` никогда не даёт `reject`, пока ниша/происхождение
+     * (единственный легитимный источник автоотказа) этого не требуют.
+     */
+    public function testNoTraceNeverRejectsWithoutNicheOrOriginGate(): void
+    {
+        $command = $this->makeCommand();
+        $match   = ['identity_match' => 'no_trace', 'control_proof' => 'unconfirmed', 'evidence' => []];
+
+        foreach ([null, 'in'] as $niche) {
+            foreach ([null, 'ru'] as $origin) {
+                $verdict = $this->invoke($command, 'decideVerdict', [$match, [], $niche, $origin]);
+                $this->assertNotSame('reject', $verdict, "niche={$niche} origin={$origin} не должны давать reject при no_trace");
+            }
+        }
+    }
+
+    public function testBuildSummaryExplainsNoTraceReason(): void
+    {
+        $command = $this->makeCommand();
+        $match   = ['identity_match' => 'no_trace', 'control_proof' => 'unconfirmed', 'evidence' => []];
+
+        $summary = $this->invoke($command, 'buildSummary', [$match, [], [], 'ниша/происхождение: бренд не зеркалирован на Mac — не определены (этап 2)']);
+
+        $this->assertStringContainsString('нужна ссылка на сайт/соцсеть', $summary);
+    }
+
+    // ── Bug 2: поиск кандидатов по контактам заявки (телефон в 3 форматах + email) ──
+
+    public function testDiscoverByContactsSearchesPhoneInThreeFormatsAndEmail(): void
+    {
+        $seenQueries = [];
+        $yandex = $this->createMock(YandexSearchClient::class);
+        $yandex->method('search')->willReturnCallback(function (string $q) use (&$seenQueries): array {
+            $seenQueries[] = $q;
+
+            return []; // ни на одном запросе ничего не находим — должны дойти до конца списка
+        });
+
+        $command = $this->makeCommand($yandex);
+        $item    = ['phone' => '+7 968 614 6174', 'email' => 'ah.silk@yandex.ru'];
+
+        $result = $this->invoke($command, 'discoverByContacts', [$item]);
+
+        $this->assertNull($result);
+        $this->assertSame(
+            ['+79686146174', '89686146174', '9686146174', 'ah.silk@yandex.ru'],
+            $seenQueries,
+        );
+    }
+
+    public function testDiscoverByContactsConfirmsCandidateAndStopsEarly(): void
+    {
+        $html = <<<'HTML'
+            <html><head><title>AH Silk</title></head>
+            <body><p>Тел: <a href="tel:+79686146174">+7 968 614-61-74</a></p></body></html>
+            HTML;
+
+        $calls  = 0;
+        $yandex = $this->createMock(YandexSearchClient::class);
+        $yandex->method('search')->willReturnCallback(function () use (&$calls): array {
+            $calls++;
+
+            return [['url' => 'https://ahsilk.ru/', 'title' => 'AH Silk', 'content' => '']];
+        });
+
+        $scraper = $this->createMock(WebScraperService::class);
+        $scraper->method('fetch')->willReturn(['url' => 'https://ahsilk.ru/', 'httpStatus' => 200, 'html' => $html]);
+
+        $command = $this->makeCommand($yandex, $scraper);
+        $item    = ['phone' => '+7 968 614 6174', 'email' => 'ah.silk@yandex.ru'];
+
+        $result = $this->invoke($command, 'discoverByContacts', [$item]);
+
+        $this->assertNotNull($result);
+        $this->assertSame('https://ahsilk.ru/', $result->url);
+        $this->assertTrue($result->live);
+        $this->assertSame(1, $calls, 'первый же запрос (+7…) уже нашёл и подтвердил кандидата — остальные форматы не нужны');
+    }
+
+    public function testDiscoverByContactsReturnsNullWithoutPhoneOrEmail(): void
+    {
+        $yandex = $this->createMock(YandexSearchClient::class);
+        $yandex->expects($this->never())->method('search');
+
+        $command = $this->makeCommand($yandex);
+
+        $this->assertNull($this->invoke($command, 'discoverByContacts', [[]]));
+    }
+}


### PR DESCRIPTION
## Что было

Первый живой прогон `app:brand:moderate-tick --dry-run --id=3673` по реальному
самрег-бренду «Русский бренд АХ!» (ahsilk.ru) выдал `verdict=reject` для
настоящего живого бренда — из-за двух дефектов конвейера.

## Bug 1 (критический): `no_trace`/`unconfirmed` → `reject`

`decideVerdict()` отклонял бренд просто по значению `identity_match`. По
утверждённой политике (`docs/brand_self_service.md` §3, таблица авто-решений)
`reject` допустим ТОЛЬКО при `niche_status='off'` или `origin_status IN
('foreign','unknown')`. Отсутствие цифрового следа — не повод для автоотказа
настоящему бренду.

Маппинг приведён в соответствие с таблицей:
- `niche='off'` или `origin foreign/unknown` → `reject` (единственный гейт);
- всё остальное (`no_trace`, `weak`, `unconfirmed`, red flags, дубли) →
  `request_changes` (в MVP отдельного статуса `awaiting_facts`/`hold_human` в
  сущности нет — не заводили новый, используем существующий `request_changes`
  и объясняем причину в `summary`).

## Bug 2: поиск сайта не использовал контакты заявки

`BrandSourceFinder::discoverTiered()` угадывает домен из слага/названия —
для патологических названий (кейс «Русский бренд АХ!», 2 значащих символа +
пунктуация) угаданный домен не существует, и конвейер сдаётся, хотя сайт
элементарно находится поиском по телефону/email заявителя.

Добавлен `ModerateTickCommand::discoverByContacts()`: если `discoverTiered()`
не дал живого own_site, ищем по контактам заявки (телефон в 3 форматах —
`+7…`, `8…`, 10 цифр — и email как есть) через тот же `YandexSearchClient`
(квота — через его собственный `YandexSearchMeter`, новых сервисов/env не
добавлено). Кандидата подтверждаем тем же `ApplicationMatcher` (не менялся) —
телефон/email реально на странице, а не просто совпал URL в выдаче.

Заодно: угаданный из слага мёртвый домен больше не помечается
`site_unreachable` — это наша неудачная догадка, а не факт о бренде.

## Изменённые файлы
- `src/Command/ModerateTickCommand.php`
- `tests/Command/ModerateTickCommandTest.php` (новый)

## Test plan
- [x] `php -d memory_limit=512M bin/phpunit` — 451 tests, 1399 assertions, OK
- [x] `ModerateTickCommandTest`: табличный тест `decideVerdict()` по строкам §3
      + явный инвариант «`no_trace` никогда не даёт `reject`» без гейта
      ниши/происхождения
- [x] `discoverByContacts()`: запросы формируются в 3 форматах телефона + email
      (мок `YandexSearchClient`, сеть не дёргали), ранний выход при первом
      подтверждённом кандидате
- [ ] Живой прогон по проду — делает автор задачи, не входит в этот PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)