### PR TITLE
fix(moderation): чинит HTTP 500 в POST /api/v1/moderation/verdict

### DIFF
--- a/src/Entity/BrandModeration.php
+++ b/src/Entity/BrandModeration.php
@@ -72,10 +72,13 @@ class BrandModeration
     #[ORM\Column(options: ['default' => 0])]
     private int $analyzeAttempts = 0;
 
-    #[ORM\Column(nullable: true)]
+    // type указан явно: DateTimeInterface (интерфейс) не входит в карту типов Doctrine
+    // (DefaultTypedFieldMapper знает только DateTime/DateTimeImmutable) — без явного type
+    // колонка молча маппится в 'string', а PDO падает при биндинге объекта DateTime.
+    #[ORM\Column(type: Types::DATETIME_MUTABLE, nullable: true)]
     private ?\DateTimeInterface $analyzedAt = null;
 
-    #[ORM\Column(nullable: true)]
+    #[ORM\Column(type: Types::DATETIME_MUTABLE, nullable: true)]
     private ?\DateTimeInterface $decidedAt = null;
 
     #[ORM\Column(length: 10, nullable: true)]

--- a/tests/Controller/Api/BrandModerationApiTest.php
+++ b/tests/Controller/Api/BrandModerationApiTest.php
@@ -4,6 +4,11 @@ declare(strict_types=1);
 
 namespace App\Tests\Controller\Api;
 
+use App\Entity\Brand;
+use App\Entity\BrandLink;
+use App\Entity\BrandModeration;
+use Doctrine\ORM\EntityManagerInterface;
+use Nevinny\AdminCoreBundle\Enum\Statuses;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
 /**
@@ -12,6 +17,9 @@ use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
  */
 class BrandModerationApiTest extends WebTestCase
 {
+    private const TOKEN  = 'test-agent-token';
+    private const SECRET = 'test-agent-secret';
+
     public function testQueueWithoutTokenReturns401(): void
     {
         $client = static::createClient();
@@ -28,5 +36,194 @@ class BrandModerationApiTest extends WebTestCase
         $this->assertResponseIsSuccessful();
         $data = json_decode($client->getResponse()->getContent(), true);
         $this->assertArrayHasKey('items', $data);
+    }
+
+    public function testVerdictMinimalPayloadReturns200AndPersistsModeration(): void
+    {
+        $client = static::createClient();
+        $em = static::getContainer()->get(EntityManagerInterface::class);
+
+        $brand = (new Brand())->setTitle('Русский бренд Ах')->setSlug('russkii-brend-akh');
+        $brand->setStatus(Statuses::Active);
+        $em->persist($brand);
+        $em->flush();
+
+        $body = json_encode([
+            'slug'            => 'russkii-brend-akh',
+            'verdict'         => 'request_changes',
+            'identity_match'  => 'confirmed',
+            'control_proof'   => 'unconfirmed',
+        ], JSON_THROW_ON_ERROR);
+
+        $this->postVerdict($client, $body);
+
+        $this->assertResponseIsSuccessful();
+        $data = json_decode($client->getResponse()->getContent(), true);
+        $this->assertSame('reviewed', $data['status']);
+        $this->assertSame($brand->getId(), $data['brand_id']);
+        $this->assertSame(1, $data['analyze_attempts']);
+
+        $moderation = $em->getRepository(BrandModeration::class)->findOneBy(['brand' => $brand]);
+        $this->assertNotNull($moderation);
+        $this->assertSame(BrandModeration::STATUS_REVIEWED, $moderation->getStatus());
+        $this->assertSame('request_changes', $moderation->getVerdict());
+        $this->assertSame('confirmed', $moderation->getIdentityMatch());
+        $this->assertSame('unconfirmed', $moderation->getControlProof());
+        $this->assertSame(BrandModeration::SOURCE_MANUAL, $moderation->getSource());
+    }
+
+    public function testVerdictWithLinksCreatesBrandLinkAndSkipsDuplicates(): void
+    {
+        $client = static::createClient();
+        $em = static::getContainer()->get(EntityManagerInterface::class);
+
+        $brand = (new Brand())->setTitle('Бренд со ссылками')->setSlug('brand-with-links');
+        $brand->setStatus(Statuses::Active);
+        $em->persist($brand);
+
+        $existing = (new BrandLink())->setBrand($brand)->setLinkUrl('https://vk.com/existing')->setLinkType('vk');
+        $existing->setTitle('vk');
+        $existing->setSlug('existing-owner-link');
+        $existing->setStatus(Statuses::Active);
+        $em->persist($existing);
+        $em->flush();
+        // KernelBrowser не ребутает kernel на первом запросе клиента → без clear() контроллер
+        // получил бы из identity map тот же PHP-объект $brand с непрогруженной инверс-стороной
+        // links (мы не звали $brand->addLink()) — тест-артефакт, не воспроизводимый в проде
+        // (там каждый HTTP-запрос всегда хидратирует бренд заново).
+        $em->clear();
+
+        $body = json_encode([
+            'slug'    => 'brand-with-links',
+            'verdict' => 'approve',
+            'links'   => [
+                ['link_type' => 'instagram', 'link_url' => 'https://instagram.com/newbrand'],
+                ['link_type' => 'vk', 'link_url' => 'https://vk.com/existing'], // дубль — не создаём
+            ],
+        ], JSON_THROW_ON_ERROR);
+
+        $this->postVerdict($client, $body);
+        $this->assertResponseIsSuccessful();
+
+        $em->clear();
+        $refreshed = $em->getRepository(Brand::class)->findOneBy(['slug' => 'brand-with-links']);
+        $urls = array_map(static fn (BrandLink $l) => $l->getLinkUrl(), $refreshed->getLinks()->toArray());
+        sort($urls);
+        $this->assertSame(['https://instagram.com/newbrand', 'https://vk.com/existing'], $urls);
+
+        // Повторный вызов не дублирует уже существующую (в т.ч. новую) ссылку.
+        $client->request(
+            'POST',
+            '/api/v1/moderation/verdict',
+            [],
+            [],
+            $this->signedHeaders($body),
+            $body,
+        );
+        $this->assertResponseIsSuccessful();
+        $em->clear();
+        $refreshed = $em->getRepository(Brand::class)->findOneBy(['slug' => 'brand-with-links']);
+        $this->assertCount(2, $refreshed->getLinks());
+    }
+
+    public function testVerdictWithNicheAndOriginStatusUpdatesBrand(): void
+    {
+        $client = static::createClient();
+        $em = static::getContainer()->get(EntityManagerInterface::class);
+
+        $brand = (new Brand())->setTitle('Нишевый бренд')->setSlug('niche-brand');
+        $brand->setStatus(Statuses::Active);
+        $em->persist($brand);
+        $em->flush();
+
+        $body = json_encode([
+            'slug'          => 'niche-brand',
+            'verdict'       => 'approve',
+            'niche_status'  => 'in',
+            'origin_status' => 'ru',
+        ], JSON_THROW_ON_ERROR);
+
+        $this->postVerdict($client, $body);
+        $this->assertResponseIsSuccessful();
+
+        $em->clear();
+        $refreshed = $em->getRepository(Brand::class)->findOneBy(['slug' => 'niche-brand']);
+        $this->assertSame('in', $refreshed->getNicheStatus());
+        $this->assertSame('ru', $refreshed->getOriginStatus());
+    }
+
+    public function testVerdictUnknownSlugReturnsNotFound(): void
+    {
+        $client = static::createClient();
+        $body = json_encode(['slug' => 'no-such-brand-slug', 'verdict' => 'approve'], JSON_THROW_ON_ERROR);
+
+        $this->postVerdict($client, $body);
+
+        $this->assertResponseIsSuccessful();
+        $data = json_decode($client->getResponse()->getContent(), true);
+        $this->assertSame('not_found', $data['status']);
+    }
+
+    public function testVerdictMissingSlugReturns422(): void
+    {
+        $client = static::createClient();
+        $body = json_encode(['verdict' => 'approve'], JSON_THROW_ON_ERROR);
+
+        $this->postVerdict($client, $body);
+
+        $this->assertResponseStatusCodeSame(422);
+    }
+
+    public function testVerdictInvalidJsonReturns400(): void
+    {
+        $client = static::createClient();
+        $body = '{not-json';
+
+        $this->postVerdict($client, $body);
+
+        $this->assertResponseStatusCodeSame(400);
+    }
+
+    public function testVerdictWithBadSignatureReturns401(): void
+    {
+        $client = static::createClient();
+        $body = json_encode(['slug' => 'russkii-brend-akh', 'verdict' => 'approve'], JSON_THROW_ON_ERROR);
+
+        $client->request(
+            'POST',
+            '/api/v1/moderation/verdict',
+            [],
+            [],
+            [
+                'HTTP_X_AGENT_TOKEN' => self::TOKEN,
+                'HTTP_X_SIGNATURE'   => 'deadbeef',
+                'CONTENT_TYPE'       => 'application/json',
+            ],
+            $body,
+        );
+
+        $this->assertResponseStatusCodeSame(401);
+    }
+
+    private function postVerdict(\Symfony\Bundle\FrameworkBundle\KernelBrowser $client, string $body): void
+    {
+        $client->request(
+            'POST',
+            '/api/v1/moderation/verdict',
+            [],
+            [],
+            $this->signedHeaders($body),
+            $body,
+        );
+    }
+
+    /** @return array<string,string> */
+    private function signedHeaders(string $body): array
+    {
+        return [
+            'HTTP_X_AGENT_TOKEN' => self::TOKEN,
+            'HTTP_X_SIGNATURE'   => hash_hmac('sha256', $body, self::SECRET),
+            'CONTENT_TYPE'       => 'application/json',
+        ];
     }
 }


### PR DESCRIPTION
## Проблема

`POST /api/v1/moderation/verdict` отдавал 500 даже на минимальном валидном payload (подпись/токен проходят, `GET /moderation/queue` работает — падала именно запись).

## Причина

`BrandModeration::$analyzedAt` / `$decidedAt` типизированы как `?\DateTimeInterface` без явного `type` в `#[ORM\Column]`. Doctrine's `DefaultTypedFieldMapper` умеет выводить тип колонки только для конкретных классов `DateTime`/`DateTimeImmutable`, но не для интерфейса `DateTimeInterface` → тип молча падает на дефолт `string`. При `setAnalyzedAt(new \DateTime())` + `flush()` Doctrine пытается забиндить объект `DateTime` в PDO-параметр как строку → `ErrorException: Object of class DateTime could not be converted to string`.

Физическая колонка в MySQL — `DATETIME` (миграция `Version20260730_brand_moderation` в порядке, не трогал). Баг чисто в маппинге сущности.

## Фикс

Добавлен явный `type: Types::DATETIME_MUTABLE` на оба поля (`analyzedAt`, `decidedAt` — второе с идентичным паттерном бага, используется в `BrandModerationController::decide`, тоже поймало бы 500).

## Тесты

`tests/Controller/Api/BrandModerationApiTest.php` — было 2 теста (только `GET /queue`), добавлено 7 на `POST /verdict`:
- минимальный вердикт (регрессия ровно того 500, что был на проде)
- `links`: создание, дедуп повторного вызова, сохранение уже существующих owner-ссылок
- `niche_status`/`origin_status` пишутся в бренд
- неизвестный slug → `not_found`
- битый JSON → 400
- отсутствующий slug → 422
- неверная подпись → 401

Тест на минимальный вердикт **падает на текущем `main`** с тем же исключением, что было на проде — воспроизведено, затем починено.

## Проверка

`/opt/homebrew/bin/php -d memory_limit=512M bin/phpunit` — 462 теста, 1429 assertions, 0 failures (только 5 pre-existing deprecations, не относятся к этой правке).

🤖 Generated with [Claude Code](https://claude.com/claude-code)