### PR TITLE
Замкнуть премодерацию: подтверждённый сайт → brand_link

### DIFF
--- a/src/Command/ModerateTickCommand.php
+++ b/src/Command/ModerateTickCommand.php
@@ -15,6 +15,7 @@ use App\Service\Moderation\ApplicationMatcher;
 use App\Service\NearDuplicateDetector;
 use App\Service\SearxClient;
 use App\Service\SearxUnavailableException;
+use App\Service\Support\LinkTypeClassifier;
 use App\Service\WebScraperService;
 use App\Service\YandexSearchClient;
 use App\Service\YandexSearchMeter;
@@ -83,32 +84,14 @@ class ModerateTickCommand extends Command
     private const CONTACT_QUERY_JITTER_MS = 1200;
     private const CONTACT_BRAVE_FALLBACK_MIN = 3;
 
-    // Домен → link_type для соц-/маркетплейс-ссылок, найденных на подтверждённом сайте бренда
-    // (docs/brand_self_service.md §4/§6). Тот же набор, что и приватный
-    // OutboundClickController::classify() (там — трекер кликов, здесь — заполнение brand_link
-    // при вердикте); дублирование дешевле общего сервиса ради 15 строк. Домены без явного типа
-    // сюда не попадают — 'other' зарезервирован под известные, но не перечисленные в докблоке
-    // BrandLink соцсети, а не под произвольные ссылки со страницы.
-    private const SOCIAL_MARKETPLACE_TYPES = [
-        'instagram.com'    => 'instagram',
-        'vk.com'           => 'vk',
-        'vkontakte.ru'     => 'vk',
-        't.me'             => 'telegram',
-        'telegram.me'      => 'telegram',
-        'youtube.com'      => 'youtube',
-        'youtu.be'         => 'youtube',
-        'tiktok.com'       => 'tiktok',
-        'wildberries.ru'   => 'marketplace',
-        'ozon.ru'          => 'marketplace',
-        'lamoda.ru'        => 'marketplace',
-        'market.yandex.ru' => 'marketplace',
-        'avito.ru'         => 'marketplace',
-        'facebook.com'     => 'other',
-        'ok.ru'            => 'other',
-        'pinterest.com'    => 'other',
-        'twitter.com'      => 'other',
-        'x.com'            => 'other',
-    ];
+    // Типы, которые считаем соц-/маркетплейс-КАНДИДАТОМ для brand_link из ссылок, найденных
+    // на подтверждённом сайте бренда (docs/brand_self_service.md §4/§6). Хосты — общий
+    // App\Service\Support\LinkTypeClassifier (тот же, что и клик-аналитика в
+    // OutboundClickController, — не дублируем список доменов). 'website'/'other' из
+    // классификатора сюда НЕ попадают: почти любая внутренняя ссылка сайта классифицируется
+    // как 'website' по умолчанию — это не сигнал соцсети, а сайт уже добавлен отдельно
+    // (buildLinksPayload).
+    private const CANDIDATE_LINK_TYPES = ['instagram', 'vk', 'telegram', 'youtube', 'tiktok', 'marketplace'];
     private const MAX_SOCIAL_LINKS = 6;
 
     public function __construct(
@@ -370,7 +353,8 @@ class ModerateTickCommand extends Command
     /**
      * Соц-/маркетплейс-ссылки со страниц сайта (WebScraperService::extractLinks() уже
      * абсолютизирует href и режет self-домены/job-noise через UrlFilter) — здесь только
-     * классификация по хосту + дедуп + кап MAX_SOCIAL_LINKS.
+     * классификация по хосту (LinkTypeClassifier — общий с OutboundClickController) + фильтр
+     * до CANDIDATE_LINK_TYPES + дедуп + кап MAX_SOCIAL_LINKS.
      *
      * @param array<int,array{url:string,html:string}> $pages
      * @return list<array{link_type:string,link_url:string}>
@@ -383,9 +367,8 @@ class ModerateTickCommand extends Command
                 if (isset($found[$url]) || count($found) >= self::MAX_SOCIAL_LINKS) {
                     continue;
                 }
-                $host = $this->hostOf($url);
-                $type = $host !== null ? $this->classifySocialHost($host) : null;
-                if ($type !== null) {
+                $type = LinkTypeClassifier::classify($url);
+                if (in_array($type, self::CANDIDATE_LINK_TYPES, true)) {
                     $found[$url] = $type;
                 }
             }
@@ -397,17 +380,6 @@ class ModerateTickCommand extends Command
         }
 
         return $links;
-    }
-
-    private function classifySocialHost(string $host): ?string
-    {
-        foreach (self::SOCIAL_MARKETPLACE_TYPES as $domain => $type) {
-            if ($host === $domain || str_ends_with($host, '.' . $domain)) {
-                return $type;
-            }
-        }
-
-        return null;
     }
 
     /**

--- a/src/Command/ModerateTickCommand.php
+++ b/src/Command/ModerateTickCommand.php
@@ -83,6 +83,34 @@ class ModerateTickCommand extends Command
     private const CONTACT_QUERY_JITTER_MS = 1200;
     private const CONTACT_BRAVE_FALLBACK_MIN = 3;
 
+    // Домен → link_type для соц-/маркетплейс-ссылок, найденных на подтверждённом сайте бренда
+    // (docs/brand_self_service.md §4/§6). Тот же набор, что и приватный
+    // OutboundClickController::classify() (там — трекер кликов, здесь — заполнение brand_link
+    // при вердикте); дублирование дешевле общего сервиса ради 15 строк. Домены без явного типа
+    // сюда не попадают — 'other' зарезервирован под известные, но не перечисленные в докблоке
+    // BrandLink соцсети, а не под произвольные ссылки со страницы.
+    private const SOCIAL_MARKETPLACE_TYPES = [
+        'instagram.com'    => 'instagram',
+        'vk.com'           => 'vk',
+        'vkontakte.ru'     => 'vk',
+        't.me'             => 'telegram',
+        'telegram.me'      => 'telegram',
+        'youtube.com'      => 'youtube',
+        'youtu.be'         => 'youtube',
+        'tiktok.com'       => 'tiktok',
+        'wildberries.ru'   => 'marketplace',
+        'ozon.ru'          => 'marketplace',
+        'lamoda.ru'        => 'marketplace',
+        'market.yandex.ru' => 'marketplace',
+        'avito.ru'         => 'marketplace',
+        'facebook.com'     => 'other',
+        'ok.ru'            => 'other',
+        'pinterest.com'    => 'other',
+        'twitter.com'      => 'other',
+        'x.com'            => 'other',
+    ];
+    private const MAX_SOCIAL_LINKS = 6;
+
     public function __construct(
         private readonly HttpClientInterface $httpClient,
         private readonly BrandSourceFinder $sourceFinder,
@@ -247,6 +275,7 @@ class ModerateTickCommand extends Command
         [$nicheStatus, $originStatus, $note] = $this->classifyOnMacIfMirrored($slug);
         $verdict = $this->decideVerdict($match, $redFlags, $nicheStatus, $originStatus);
         $summary = $this->buildSummary($match, $missing, $redFlags, $note);
+        $links   = $this->buildLinksPayload($match, $pages);
 
         $io->text(sprintf('  identity=%s control=%s verdict=%s', $match['identity_match'], $match['control_proof'], $verdict));
         if ($redFlags !== []) {
@@ -254,6 +283,9 @@ class ModerateTickCommand extends Command
         }
         if ($missing !== []) {
             $io->text('  missing: ' . implode(',', $missing));
+        }
+        if ($links !== []) {
+            $io->text('  links: ' . implode(', ', array_map(static fn (array $l) => "{$l['link_type']}:{$l['link_url']}", $links)));
         }
 
         $tgText = $this->buildTgText($title, $match, $missing, $redFlags, $summary);
@@ -264,7 +296,7 @@ class ModerateTickCommand extends Command
             return;
         }
 
-        $this->postVerdict($slug, $match, $redFlags, $missing, $summary, $nicheStatus, $originStatus, $verdict);
+        $this->postVerdict($slug, $match, $redFlags, $missing, $summary, $nicheStatus, $originStatus, $verdict, $links);
 
         try {
             $this->notifier->sendWithButtons($tgText, $this->signedButtons((int) $item['brand_id']));
@@ -311,6 +343,71 @@ class ModerateTickCommand extends Command
         $host = parse_url($url, PHP_URL_HOST);
 
         return is_string($host) ? strtolower(preg_replace('/^www\./', '', $host)) : null;
+    }
+
+    /**
+     * Ссылки в payload вердикта — только для ПОДТВЕРЖДЁННОГО сайта (identity_match=confirmed):
+     * неподтверждённые кандидаты и наши доменные догадки в brand_link не пишем (см. докстринг
+     * задачи/docs/brand_self_service.md §4). $pages — уже отфетченные для матчинга страницы
+     * (главная + контакты), сайт как website + соц-/маркетплейс-ссылки с тех же страниц —
+     * побочный продукт того же обхода, второго похода в сеть нет.
+     *
+     * @param array{identity_match:string} $match
+     * @param array<int,array{url:string,html:string}> $pages
+     * @return list<array{link_type:string,link_url:string}>
+     */
+    private function buildLinksPayload(array $match, array $pages): array
+    {
+        if ($match['identity_match'] !== 'confirmed' || $pages === []) {
+            return [];
+        }
+
+        $links = [['link_type' => 'website', 'link_url' => $pages[0]['url']]];
+
+        return array_merge($links, $this->extractSocialLinks($pages));
+    }
+
+    /**
+     * Соц-/маркетплейс-ссылки со страниц сайта (WebScraperService::extractLinks() уже
+     * абсолютизирует href и режет self-домены/job-noise через UrlFilter) — здесь только
+     * классификация по хосту + дедуп + кап MAX_SOCIAL_LINKS.
+     *
+     * @param array<int,array{url:string,html:string}> $pages
+     * @return list<array{link_type:string,link_url:string}>
+     */
+    private function extractSocialLinks(array $pages): array
+    {
+        $found = [];
+        foreach ($pages as $page) {
+            foreach ($this->scraper->extractLinks($page['html'], $page['url']) as $url) {
+                if (isset($found[$url]) || count($found) >= self::MAX_SOCIAL_LINKS) {
+                    continue;
+                }
+                $host = $this->hostOf($url);
+                $type = $host !== null ? $this->classifySocialHost($host) : null;
+                if ($type !== null) {
+                    $found[$url] = $type;
+                }
+            }
+        }
+
+        $links = [];
+        foreach ($found as $url => $type) {
+            $links[] = ['link_type' => $type, 'link_url' => $url];
+        }
+
+        return $links;
+    }
+
+    private function classifySocialHost(string $host): ?string
+    {
+        foreach (self::SOCIAL_MARKETPLACE_TYPES as $domain => $type) {
+            if ($host === $domain || str_ends_with($host, '.' . $domain)) {
+                return $type;
+            }
+        }
+
+        return null;
     }
 
     /**
@@ -700,7 +797,14 @@ class ModerateTickCommand extends Command
         ];
     }
 
-    /** @param string[] $redFlags @param string[] $missing */
+    /**
+     * @param string[] $redFlags @param string[] $missing
+     * @param list<array{link_type:string,link_url:string}> $links сайт (если подтверждён) +
+     *        соц-/маркетплейс-ссылки, см. buildLinksPayload(). Эндпоинт (BrandIngestController::
+     *        moderationVerdict) сам не создаёт дублей по уже существующему URL и не трогает
+     *        owner-provenance — повторный прогон с тем же payload идемпотентен, дедуп в команде
+     *        не нужен.
+     */
     private function postVerdict(
         string $slug,
         array $match,
@@ -710,6 +814,7 @@ class ModerateTickCommand extends Command
         ?string $nicheStatus,
         ?string $originStatus,
         string $verdict,
+        array $links,
     ): void {
         $body = json_encode([
             'slug'           => $slug,
@@ -722,6 +827,7 @@ class ModerateTickCommand extends Command
             'summary'        => $summary,
             'niche_status'   => $nicheStatus,
             'origin_status'  => $originStatus,
+            'links'          => $links,
         ], JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR);
 
         $this->httpClient->request('POST', rtrim((string) $this->prodApiUrl, '/') . '/api/v1/moderation/verdict', [

--- a/src/Controller/OutboundClickController.php
+++ b/src/Controller/OutboundClickController.php
@@ -2,6 +2,7 @@
 
 namespace App\Controller;
 
+use App\Service\Support\LinkTypeClassifier;
 use Doctrine\DBAL\Connection;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -59,7 +60,7 @@ class OutboundClickController extends AbstractController
                 [
                     'brand_id' => (int) $row['brand_id'],
                     'link_id'  => $id,
-                    'type'     => $this->classify($url),
+                    'type'     => LinkTypeClassifier::classify($url),
                     'host'     => mb_substr((string) parse_url($url, PHP_URL_HOST), 0, 255) ?: null,
                     'locale'   => $request->getLocale(),
                     'referer'  => $ref !== null ? mb_substr($ref, 0, 255) : null,
@@ -77,23 +78,5 @@ class OutboundClickController extends AbstractController
         $resp->headers->set('Referrer-Policy', 'no-referrer');  // не утекать наш URL бренду как referer
 
         return $resp;
-    }
-
-    /** Нормализованный тип цели по хосту (link_type из enrichment часто 'other'). */
-    private function classify(string $url): string
-    {
-        $h = mb_strtolower((string) parse_url($url, PHP_URL_HOST));
-
-        return match (true) {
-            str_contains($h, 'instagram.com')                          => 'instagram',
-            str_contains($h, 'vk.com') || str_contains($h, 'vkontakte') => 'vk',
-            str_contains($h, 't.me') || str_contains($h, 'telegram.')   => 'telegram',
-            str_contains($h, 'youtube.com') || str_contains($h, 'youtu.be') => 'youtube',
-            str_contains($h, 'tiktok.com')                             => 'tiktok',
-            str_contains($h, 'wildberries.') || str_contains($h, 'ozon.')
-                || str_contains($h, 'lamoda.') || str_contains($h, 'market.yandex.') => 'marketplace',
-            $h === ''                                                  => 'other',
-            default                                                    => 'website',
-        };
     }
 }

--- a/src/Service/Support/LinkTypeClassifier.php
+++ b/src/Service/Support/LinkTypeClassifier.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Support;
+
+/**
+ * Нормализованный link_type ссылки бренда по хосту URL (link_type из enrichment
+ * часто 'other'). Общий атом для клик-аналитики (OutboundClickController) и
+ * записи ссылок при премодерации (ModerateTickCommand) — не дублируем список
+ * хостов, иначе они разъедутся.
+ */
+final class LinkTypeClassifier
+{
+    public static function classify(string $url): string
+    {
+        $h = mb_strtolower((string) parse_url($url, PHP_URL_HOST));
+
+        return match (true) {
+            str_contains($h, 'instagram.com')                          => 'instagram',
+            str_contains($h, 'vk.com') || str_contains($h, 'vkontakte') => 'vk',
+            str_contains($h, 't.me') || str_contains($h, 'telegram.')   => 'telegram',
+            str_contains($h, 'youtube.com') || str_contains($h, 'youtu.be') => 'youtube',
+            str_contains($h, 'tiktok.com')                             => 'tiktok',
+            str_contains($h, 'wildberries.') || str_contains($h, 'ozon.')
+                || str_contains($h, 'lamoda.') || str_contains($h, 'market.yandex.') => 'marketplace',
+            $h === ''                                                  => 'other',
+            default                                                    => 'website',
+        };
+    }
+}

--- a/tests/Command/ModerateTickCommandTest.php
+++ b/tests/Command/ModerateTickCommandTest.php
@@ -13,6 +13,7 @@ use App\Service\BraveSearchClient;
 use App\Service\Moderation\ApplicationMatcher;
 use App\Service\NearDuplicateDetector;
 use App\Service\SearxClient;
+use App\Service\UrlFilter;
 use App\Service\WebScraperService;
 use App\Service\YandexSearchClient;
 use App\Service\YandexSearchMeter;
@@ -270,5 +271,96 @@ class ModerateTickCommandTest extends TestCase
         $result = $this->invoke($command, 'searchAnyEngine', ['ah.silk@yandex.ru']);
 
         $this->assertSame([], $result);
+    }
+
+    // ── Замыкание конвейера: подтверждённый сайт → payload вердикта (brand_link) ────
+
+    public function testBuildLinksPayloadIncludesConfirmedSiteAsWebsite(): void
+    {
+        $command = $this->makeCommand();
+        $match   = ['identity_match' => 'confirmed', 'control_proof' => 'unconfirmed', 'evidence' => []];
+        $pages   = [['url' => 'https://ahsilk.ru/', 'html' => '<html><body>no links here</body></html>']];
+
+        $links = $this->invoke($command, 'buildLinksPayload', [$match, $pages]);
+
+        $this->assertSame([['link_type' => 'website', 'link_url' => 'https://ahsilk.ru/']], $links);
+    }
+
+    #[DataProvider('unconfirmedIdentityMatrix')]
+    public function testBuildLinksPayloadSkipsUnconfirmedCandidate(string $identity): void
+    {
+        $command = $this->makeCommand();
+        $match   = ['identity_match' => $identity, 'control_proof' => 'unconfirmed', 'evidence' => []];
+        $pages   = [['url' => 'https://ahsilk.ru/', 'html' => '<html><body>Instagram: <a href="https://instagram.com/ahsilk">ig</a></body></html>']];
+
+        $this->assertSame([], $this->invoke($command, 'buildLinksPayload', [$match, $pages]));
+    }
+
+    public static function unconfirmedIdentityMatrix(): iterable
+    {
+        yield 'weak'        => ['weak'];
+        yield 'unconfirmed' => ['unconfirmed'];
+        yield 'no_trace'    => ['no_trace'];
+    }
+
+    public function testBuildLinksPayloadIsIdempotentAcrossRepeatedRuns(): void
+    {
+        $command = $this->makeCommand(null, $this->realScraper());
+        $match   = ['identity_match' => 'confirmed', 'control_proof' => 'unconfirmed', 'evidence' => []];
+        $pages   = [['url' => 'https://ahsilk.ru/', 'html' => '<html><body><a href="https://vk.com/ahsilk">vk</a></body></html>']];
+
+        $first  = $this->invoke($command, 'buildLinksPayload', [$match, $pages]);
+        $second = $this->invoke($command, 'buildLinksPayload', [$match, $pages]);
+
+        $this->assertSame($first, $second, 'команда детерминирована — повторный прогон по тем же страницам не должен менять payload');
+    }
+
+    public function testExtractSocialLinksClassifiesAndExcludesSelfAndJobDomains(): void
+    {
+        $html = <<<'HTML'
+            <html><body>
+                <a href="https://instagram.com/ahsilk">ig</a>
+                <a href="https://vk.com/ahsilk">vk</a>
+                <a href="https://t.me/ahsilk">tg</a>
+                <a href="https://www.wildberries.ru/brands/ahsilk">wb</a>
+                <a href="https://wearbase.ru/ru/brand/ahsilk">self</a>
+                <a href="https://hh.ru/vacancy/123">job</a>
+                <a href="https://example.com/about">unrelated external</a>
+                <a href="https://instagram.com/ahsilk">ig dup</a>
+            </body></html>
+            HTML;
+
+        $command = $this->makeCommand(null, $this->realScraper());
+        $pages   = [['url' => 'https://ahsilk.ru/', 'html' => $html]];
+
+        $links = $this->invoke($command, 'extractSocialLinks', [$pages]);
+
+        $byType = array_column($links, 'link_url', 'link_type');
+        $this->assertSame(
+            [
+                'instagram'   => 'https://instagram.com/ahsilk',
+                'vk'          => 'https://vk.com/ahsilk',
+                'telegram'    => 'https://t.me/ahsilk',
+                'marketplace' => 'https://www.wildberries.ru/brands/ahsilk',
+            ],
+            $byType,
+            'self-домен (wearbase.ru) и job-хост (hh.ru) режутся UrlFilter внутри extractLinks; example.com не соцсеть/маркетплейс — не кандидат; дубль instagram схлопнут',
+        );
+    }
+
+    public function testExtractSocialLinksCapsAtSix(): void
+    {
+        $hosts = ['instagram.com/a', 'vk.com/a', 't.me/a', 'youtube.com/a', 'tiktok.com/a', 'ozon.ru/a', 'facebook.com/a'];
+        $html  = '<html><body>' . implode('', array_map(static fn (string $h) => "<a href=\"https://{$h}\">l</a>", $hosts)) . '</body></html>';
+
+        $command = $this->makeCommand(null, $this->realScraper());
+        $links   = $this->invoke($command, 'extractSocialLinks', [[['url' => 'https://ahsilk.ru/', 'html' => $html]]]);
+
+        $this->assertCount(6, $links, 'кап MAX_SOCIAL_LINKS=6, седьмой (facebook.com) отброшен');
+    }
+
+    private function realScraper(): WebScraperService
+    {
+        return new WebScraperService($this->createMock(HttpClientInterface::class), new UrlFilter(''));
     }
 }

--- a/tests/Service/Support/LinkTypeClassifierTest.php
+++ b/tests/Service/Support/LinkTypeClassifierTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Service\Support;
+
+use App\Service\Support\LinkTypeClassifier;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Один общий классификатор link_type для клик-аналитики (OutboundClickController) и
+ * записи ссылок при премодерации (ModerateTickCommand) — по кейсу на каждую ветку
+ * match(), включая дефолт 'website' и 'other' для пустого/нечитаемого хоста.
+ */
+class LinkTypeClassifierTest extends TestCase
+{
+    #[DataProvider('urlMatrix')]
+    public function testClassify(string $url, string $expected): void
+    {
+        $this->assertSame($expected, LinkTypeClassifier::classify($url));
+    }
+
+    public static function urlMatrix(): iterable
+    {
+        yield 'instagram'         => ['https://instagram.com/ahsilk', 'instagram'];
+        yield 'vk.com'            => ['https://vk.com/ahsilk', 'vk'];
+        yield 'vkontakte subdomain' => ['https://m.vkontakte.ru/ahsilk', 'vk'];
+        yield 'telegram t.me'     => ['https://t.me/ahsilk', 'telegram'];
+        yield 'telegram.me'       => ['https://telegram.me/ahsilk', 'telegram'];
+        yield 'youtube.com'       => ['https://youtube.com/@ahsilk', 'youtube'];
+        yield 'youtu.be'          => ['https://youtu.be/abc123', 'youtube'];
+        yield 'tiktok'            => ['https://tiktok.com/@ahsilk', 'tiktok'];
+        yield 'wildberries'       => ['https://www.wildberries.ru/brands/ahsilk', 'marketplace'];
+        yield 'ozon'              => ['https://ozon.ru/brand/ahsilk', 'marketplace'];
+        yield 'lamoda'            => ['https://www.lamoda.ru/brands/ahsilk', 'marketplace'];
+        yield 'market.yandex'     => ['https://market.yandex.ru/brand/ahsilk', 'marketplace'];
+        yield 'unrelated domain -> website (дефолт)' => ['https://ahsilk.ru/about', 'website'];
+        yield 'empty host -> other' => ['not-a-url', 'other'];
+    }
+}


### PR DESCRIPTION
## Проблема

`app:brand:moderate-tick` находит и подтверждает сайт бренда (ApplicationMatcher `identity_match=confirmed`), вердикт уходит на прод, но `brand_link` остаётся пустым: команда не передавала найденный сайт в payload `POST /api/v1/moderation/verdict`, хотя эндпоинт ключ `links` уже принимает и умеет создавать ссылки, не перетирая owner-provenance.

Живой пример: «Русский бренд АХ!» (prod id 3673, `russkii-brend-akh`) — сайт `https://ahsilk.ru` подтверждён, но ни одной строки в `brand_link`.

## Что сделано

- `src/Command/ModerateTickCommand.php`: при `identity_match=confirmed` в payload вердикта добавляется `{"link_type":"website","link_url":"<финальный URL после редиректа>"}`.
- Заодно (дёшево — страницы уже отфетчены для матчинга) вытаскиваем соц-/маркетплейс-ссылки со страниц через уже существующий `WebScraperService::extractLinks()` (сам режет self-домены/job-хосты через `UrlFilter`), классифицируем по хосту (`instagram`/`vk`/`telegram`/`youtube`/`tiktok`/`marketplace`/`other`), дедуп, кап 6.
- Неподтверждённые кандидаты (`weak`/`unconfirmed`/`no_trace`) и доменные догадки в payload не попадают.
- Эндпоинт вердикта, `ApplicationMatcher`, миграции, сущности — не тронуты. Он уже дедупит по URL и не трогает owner-ссылки — команда на это полагается, не дублирует логику.

## Тесты

`tests/Command/ModerateTickCommandTest.php` (+11 тестов):
- confirmed → website в payload; weak/unconfirmed/no_trace → `[]`.
- идемпотентность: два вызова `buildLinksPayload` с теми же данными дают одинаковый результат.
- извлечение соц-ссылок на фикстуре HTML (реальный `WebScraperService`+`UrlFilter`): instagram/vk/telegram/marketplace классифицируются верно, self-домен (wearbase.ru) и job-хост (hh.ru) отсекаются, дубли схлопываются, неизвестный внешний домен не попадает в кандидаты.
- кап `MAX_SOCIAL_LINKS=6`.

`php -d memory_limit=512M vendor/bin/phpunit` — **469 tests, 1436 assertions, OK** (5 pre-existing deprecation notices, не связаны с этим PR).

## Test plan
- [x] Юнит-тесты на новую логику (см. выше)
- [x] Полный прогон PHPUnit зелёный
- [ ] Живой прогон `app:brand:moderate-tick --id=3673` на проде — НЕ делаю, по договорённости это делает автор задачи