### PR TITLE
fix(moderation): явный ?id= в очереди премодерации игнорирует status

### DIFF
--- a/src/Controller/Api/BrandIngestController.php
+++ b/src/Controller/Api/BrandIngestController.php
@@ -611,8 +611,9 @@ class BrandIngestController extends AbstractController
     /**
      * Очередь премодерации самрег-брендов (agent-pull): app:brand:moderate-tick (Mac) читает
      * досье и прогоняет ApplicationMatcher. Токен обязателен (без подписи тела — GET без бизнес-
-     * эффекта). `?id=` — узкий фильтр на один бренд (ручной прогон `--id`, счётчик analyze_attempts
-     * для гейта «не долбить после 3 попыток»).
+     * эффекта). Без `?id=` — только заявки `status='queued'` (автопрогон очереди); с явным `?id=`
+     * бренд отдаётся независимо от статуса (ручной повторный прогон `--id`, статус не фильтруется) —
+     * но только если строка `brand_moderation` для него уже существует, эндпоинт её не заводит.
      */
     #[Route('/moderation/queue', name: 'api_moderation_queue', methods: ['GET'])]
     public function moderationQueue(
@@ -639,8 +640,7 @@ class BrandIngestController extends AbstractController
                   JOIN brand b ON b.id = bm.brand_id
                   LEFT JOIN brand_user bu ON bu.brand_id = b.id AND bu.role = 'owner'
                   LEFT JOIN client owner ON owner.id = bu.user_id
-                 WHERE bm.status = 'queued'"
-            . ($id !== null ? ' AND b.id = ' . (int) $id : '')
+                 WHERE " . ($id !== null ? 'b.id = ' . (int) $id : "bm.status = 'queued'")
             . ' ORDER BY bm.created_at ASC LIMIT ' . $limit;
 
         $rows = $em->getConnection()->fetchAllAssociative($sql);

--- a/tests/Controller/Api/BrandModerationApiTest.php
+++ b/tests/Controller/Api/BrandModerationApiTest.php
@@ -38,6 +38,70 @@ class BrandModerationApiTest extends WebTestCase
         $this->assertArrayHasKey('items', $data);
     }
 
+    public function testQueueWithoutIdExcludesReviewedModeration(): void
+    {
+        $client = static::createClient();
+        $em = static::getContainer()->get(EntityManagerInterface::class);
+
+        $brand = (new Brand())->setTitle('Проверенный бренд')->setSlug('reviewed-brand');
+        $brand->setStatus(Statuses::Active);
+        $em->persist($brand);
+
+        $moderation = (new BrandModeration())->setBrand($brand)->setStatus(BrandModeration::STATUS_REVIEWED);
+        $em->persist($moderation);
+        $em->flush();
+
+        $client->request('GET', '/api/v1/moderation/queue', [], [], ['HTTP_X_AGENT_TOKEN' => self::TOKEN]);
+
+        $this->assertResponseIsSuccessful();
+        $data = json_decode($client->getResponse()->getContent(), true);
+        $brandIds = array_column($data['items'], 'brand_id');
+        $this->assertNotContains($brand->getId(), $brandIds);
+    }
+
+    public function testQueueWithExplicitIdReturnsRegardlessOfStatus(): void
+    {
+        $client = static::createClient();
+        $em = static::getContainer()->get(EntityManagerInterface::class);
+
+        $brand = (new Brand())->setTitle('Проверенный бренд 2')->setSlug('reviewed-brand-2');
+        $brand->setStatus(Statuses::Active);
+        $em->persist($brand);
+
+        $moderation = (new BrandModeration())->setBrand($brand)->setStatus(BrandModeration::STATUS_REVIEWED);
+        $em->persist($moderation);
+        $em->flush();
+
+        $client->request(
+            'GET',
+            '/api/v1/moderation/queue?id=' . $brand->getId(),
+            [],
+            [],
+            ['HTTP_X_AGENT_TOKEN' => self::TOKEN],
+        );
+
+        $this->assertResponseIsSuccessful();
+        $data = json_decode($client->getResponse()->getContent(), true);
+        $this->assertCount(1, $data['items']);
+        $this->assertSame($brand->getId(), $data['items'][0]['brand_id']);
+    }
+
+    public function testQueueWithUnknownIdReturnsEmptyNot500(): void
+    {
+        $client = static::createClient();
+        $client->request(
+            'GET',
+            '/api/v1/moderation/queue?id=999999',
+            [],
+            [],
+            ['HTTP_X_AGENT_TOKEN' => self::TOKEN],
+        );
+
+        $this->assertResponseIsSuccessful();
+        $data = json_decode($client->getResponse()->getContent(), true);
+        $this->assertSame([], $data['items']);
+    }
+
     public function testVerdictMinimalPayloadReturns200AndPersistsModeration(): void
     {
         $client = static::createClient();


### PR DESCRIPTION
## Проблема
`GET /api/v1/moderation/queue` всегда фильтровал по `bm.status = 'queued'`, даже когда в query передан явный `id`. После первого прогона `app:brand:moderate-tick --id=<brand>` статус заявки становился `reviewed`, и повторный точечный прогон по тому же бренду получал пустую очередь — блокирует ручную перепроверку после дозаполнения карточки владельцем и отладку.

## Изменения
- `src/Controller/Api/BrandIngestController.php::moderationQueue` — фильтр `status='queued'` применяется только когда `id` не передан; при явном `id` бренд отдаётся независимо от статуса (строка `brand_moderation` должна существовать — эндпоинт её не заводит).
- Докблок метода обновлён с явной семантикой: без `id` — только `queued`; с `id` — статус игнорируется.
- Тесты в `tests/Controller/Api/BrandModerationApiTest.php`:
  - заявка `status='reviewed'` не попадает в список без `id`;
  - та же заявка возвращается при запросе с `?id=<brand id>`;
  - `?id=` несуществующего бренда → пустой список, не 500.

## Test plan
- [x] `/opt/homebrew/bin/php -d memory_limit=512M vendor/bin/phpunit tests/Controller/Api/BrandModerationApiTest.php` — 12/12 зелёные
- [x] Полный прогон `vendor/bin/phpunit` — 486 тестов, 1457 assertions, OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)