### PR TITLE
chore(log): ротация dev-логов — dev.log дорос до 1,5 ГБ без единой ротации

### DIFF
--- a/config/packages/monolog.yaml
+++ b/config/packages/monolog.yaml
@@ -7,11 +7,24 @@ monolog:
 when@dev:
     monolog:
         handlers:
+            # rotating_file, а не stream: единый dev.log никогда не ротировался и дорос до
+            # 1,5 ГБ за 9 месяцев (2025-11-05 → 2026-07-31). На Mac это ещё и внешний том.
+            # Крон тикает раз в минуту, 66% объёма — http_client.INFO (каждый исходящий
+            # запрос RAG/GSC/ollama), т.е. само по себе объём не уймётся: нужен лимит.
             main:
-                type: stream
+                type: rotating_file
+                max_files: 7
                 path: "%kernel.logs_dir%/%kernel.environment%.log"
                 level: debug
-                channels: ["!event"]
+                channels: ["!event", "!deprecation"]
+            # deprecation — в свой файл, ровно как уже сделано в when@prod ниже: в main это
+            # давало 27% объёма при пяти повторяющихся сообщениях.
+            deprecation:
+                type: rotating_file
+                max_files: 3
+                path: "%kernel.logs_dir%/deprecation.log"
+                level: info
+                channels: [deprecation]
             telegram:
                 type: stream
                 path: "%kernel.logs_dir%/telegram.log"


### PR DESCRIPTION
Найдено при разборе крон-сбоя ([#80](https://github.com/nevinny/wearbase/pull/80)) — `var/log/dev.log` весил **1,5 ГБ**: хендлер `main` в `when@dev` писал `type: stream` в один файл с 5 ноября 2025 года, ни одной ротации. На Mac это ещё и внешний том.

Само по себе не уймётся: крон тикает раз в минуту, и по составу последних 200k строк **66% объёма — `http_client.INFO`** (каждый исходящий запрос RAG/GSC/ollama), 27% — `deprecation.INFO` при пяти повторяющихся сообщениях.

## Правки

- `main` → `rotating_file`, `max_files: 7`;
- `deprecation` вынесен в свой `rotating_file` (`max_files: 3`). Приём не выдуман: `when@prod` уже исключает этот канал из `main` и держит для него отдельный хендлер — повторяю ту же структуру в dev.

## Проверка

- `rm -rf var/cache/dev && cache:clear` → прогон команды создаёт `dev-2026-07-31.log` и `deprecation-2026-07-31.log`; повторный прогон растит новый файл, mtime старого `dev.log` не двигается (осиротел, как и ожидалось).
- Ссылок на путь `var/log/dev.log` в репозитории нет (grep по sh/php/yaml/md/plist) — смена имени на `dev-YYYY-MM-DD.log` ничего не рвёт.
- `tests/Command/` — 80 тестов зелёные (контейнер собирается).
- Старый файл обрезан на месте до последних 20 МБ, освободилось ~1,5 ГБ. Хвост сохранён намеренно: в нём 76 трейсов падений `app:social:generate` (`getValue() on null` в Doctrine `UnitOfWork:749`), которые ещё предстоит разобрать.

🤖 Generated with [Claude Code](https://claude.com/claude-code)