### PR TITLE
feat(kb): канал kuznecov_coach в реестр базы знаний

### DIFF
--- a/config/knowledge/channels.yaml
+++ b/config/knowledge/channels.yaml
@@ -8,6 +8,7 @@ channels:
   mtokovinin:            { role: framing, name: "Токовинин" }
   AlexanderSokolovskiy:  { role: case,    name: "Соколовский" }
   FedotovM:              { role: tone,    name: "Федотов" }
+  kuznecov_coach:        { role: tone,    name: "Кузнецов (копирайтинг)" }
   drmaxseo:              { role: seo,     name: "DrMax SEO" }
   freychu:               { role: seo,     name: "Frey Chu (directories)" }
   big_bad_coach:         { role: seo,     name: "big_bad_coach" }


### PR DESCRIPTION
## Summary
- Новый YouTube-канал для RAG-советника: kuznecov_coach (Роман Кузнецов, копирайтинг/продажи), role=tone
- Первое видео канала уже заингесчено в topic_chunks через /yt-ingest
- Это только yaml-реестр (config/knowledge/channels.yaml), PHP-код не тронут

## Test plan
- [x] Локально: диф ограничен одной строкой в channels.yaml
- [x] CI: PHPUnit на PR (изменение не затрагивает код)

🤖 Generated with [Claude Code](https://claude.com/claude-code)