### PR TITLE
fix(tests): утечка set_time_limit(5) из parser-теста ломала CI и блокировала автодеплой

### DIFF
--- a/tests/Service/ArticleMarkdownParserTest.php
+++ b/tests/Service/ArticleMarkdownParserTest.php
@@ -76,16 +76,22 @@ class ArticleMarkdownParserTest extends TestCase
      * mdToHtml() в бесконечный цикл (accumulator абзаца и ветка заголовка обе
      * отвергали строку, не продвигая курсор). set_time_limit — страховка: если
      * защита когда-нибудь регрессирует, тест упадёт по таймауту, а не подвесит
-     * весь прогон.
+     * весь прогон. Лимит действует на весь остаток PHP-процесса (не только на
+     * этот тест) — finally возвращает безлимит CLI, иначе GD-тяжёлые тесты
+     * дальше по суите падают fatal'ом на медленном CI-раннере.
      */
     public function testStrayHeadingMarkerDoesNotHang(): void
     {
         set_time_limit(5);
 
-        $md = "# Заголовок\n\n## Коротко\n\nОтвет.\n\nтекст\n##\n\nещё текст\n### \n\n"
-            . "## Раздел\n\n- пункт [ссылка](https://example.com)\n";
+        try {
+            $md = "# Заголовок\n\n## Коротко\n\nОтвет.\n\nтекст\n##\n\nещё текст\n### \n\n"
+                . "## Раздел\n\n- пункт [ссылка](https://example.com)\n";
 
-        $result = (new ArticleMarkdownParser())->parse($md);
+            $result = (new ArticleMarkdownParser())->parse($md);
+        } finally {
+            set_time_limit(0);
+        }
 
         self::assertNotNull($result);
         [$title, , $html] = $result;


### PR DESCRIPTION
## Что
`testStrayHeadingMarkerDoesNotHang` ставит `set_time_limit(5)` как страховку от регресса-зависания парсера, но лимит действует на весь остаток PHPUnit-процесса — его никто не возвращал.

## Симптом
На медленном shared CI-раннере 5-секундный бюджет исполнения кончался дальше по суите — детерминированный fatal `Maximum execution time of 5 seconds exceeded` в GD-тяжёлом `GallerySlideRendererTest` (`GallerySlideRenderer.php:468` — жертва, не виновник). Локально на Mac суита успевает, поэтому падало только в CI: **все PR красные, job Deploy to prod скипается на каждом мерже в main** (пример — ран 30908587336).

## Фикс
`try/finally` вокруг проверяемого вызова парсера: `set_time_limit(0)` (дефолт CLI) возвращается сразу после него. Страховка теста сохранена — регресс-зависание по-прежнему уронит тест по таймауту.

## Проверка
- Локально: `ArticleMarkdownParserTest` + `GallerySlideRendererTest` — 15 тестов, 149 ассертов, OK.
- Настоящая проверка — CI этого PR: до фикса он красный на любом PR, после должен позеленеть на том же раннере.

🤖 Generated with [Claude Code](https://claude.com/claude-code)