### PR TITLE
fix(wardrobe): keep public entry accessible

### DIFF
--- a/templates/tailwind/base.html.twig
+++ b/templates/tailwind/base.html.twig
@@ -114,7 +114,7 @@
             <a href="{{ path('home_hub', {_locale: nav_locale}) }}" class="text-gray-700 hover:text-indigo-600 transition">Главная</a>
             <a href="{{ path('brand_index', {_locale: nav_locale}) }}" class="text-gray-700 hover:text-indigo-600 transition">Бренды</a>
             <a href="{{ path('catalog_index') }}" class="text-gray-700 hover:text-indigo-600 transition">Каталог</a>
-            <a href="{{ path('account_wardrobe_app') }}" class="font-semibold text-indigo-600 hover:text-indigo-800 transition">Гардероб</a>
+            <a href="{{ path('landing_wardrobe', {_locale: nav_locale}) }}" class="font-semibold text-indigo-600 hover:text-indigo-800 transition">Гардероб</a>
             <a href="{{ path('brand_cities', {_locale: nav_locale}) }}" class="text-gray-700 hover:text-indigo-600 transition">Города</a>
             <a href="{{ path('brand_styles', {_locale: nav_locale}) }}" class="text-gray-700 hover:text-indigo-600 transition">Стили</a>
         </nav>
@@ -223,7 +223,7 @@
             <a href="{{ path('home_hub', {_locale: nav_locale}) }}" class="py-2 text-gray-700 hover:text-indigo-600 transition">Главная</a>
             <a href="{{ path('brand_index', {_locale: nav_locale}) }}" class="py-2 text-gray-700 hover:text-indigo-600 transition">Бренды</a>
             <a href="{{ path('catalog_index') }}" class="py-2 text-gray-700 hover:text-indigo-600 transition">Каталог</a>
-            <a href="{{ path('account_wardrobe_app') }}" class="py-2 font-semibold text-indigo-600 hover:text-indigo-800 transition">Гардероб</a>
+            <a href="{{ path('landing_wardrobe', {_locale: nav_locale}) }}" class="py-2 font-semibold text-indigo-600 hover:text-indigo-800 transition">Гардероб</a>
             <a href="{{ path('brand_cities', {_locale: nav_locale}) }}" class="py-2 text-gray-700 hover:text-indigo-600 transition">Города</a>
             <a href="{{ path('brand_styles', {_locale: nav_locale}) }}" class="py-2 text-gray-700 hover:text-indigo-600 transition">Стили</a>
 

--- a/templates/tailwind/base.html.twig
+++ b/templates/tailwind/base.html.twig
@@ -114,7 +114,7 @@
             <a href="{{ path('home_hub', {_locale: nav_locale}) }}" class="text-gray-700 hover:text-indigo-600 transition">Главная</a>
             <a href="{{ path('brand_index', {_locale: nav_locale}) }}" class="text-gray-700 hover:text-indigo-600 transition">Бренды</a>
             <a href="{{ path('catalog_index') }}" class="text-gray-700 hover:text-indigo-600 transition">Каталог</a>
-            <a href="{{ path('landing_wardrobe', {_locale: nav_locale}) }}" class="font-semibold text-indigo-600 hover:text-indigo-800 transition">Гардероб</a>
+            <a href="{{ path('landing_wardrobe', {_locale: nav_locale in ['en', 'ru'] ? nav_locale : 'ru'}) }}" class="font-semibold text-indigo-600 hover:text-indigo-800 transition">Гардероб</a>
             <a href="{{ path('brand_cities', {_locale: nav_locale}) }}" class="text-gray-700 hover:text-indigo-600 transition">Города</a>
             <a href="{{ path('brand_styles', {_locale: nav_locale}) }}" class="text-gray-700 hover:text-indigo-600 transition">Стили</a>
         </nav>
@@ -223,7 +223,7 @@
             <a href="{{ path('home_hub', {_locale: nav_locale}) }}" class="py-2 text-gray-700 hover:text-indigo-600 transition">Главная</a>
             <a href="{{ path('brand_index', {_locale: nav_locale}) }}" class="py-2 text-gray-700 hover:text-indigo-600 transition">Бренды</a>
             <a href="{{ path('catalog_index') }}" class="py-2 text-gray-700 hover:text-indigo-600 transition">Каталог</a>
-            <a href="{{ path('landing_wardrobe', {_locale: nav_locale}) }}" class="py-2 font-semibold text-indigo-600 hover:text-indigo-800 transition">Гардероб</a>
+            <a href="{{ path('landing_wardrobe', {_locale: nav_locale in ['en', 'ru'] ? nav_locale : 'ru'}) }}" class="py-2 font-semibold text-indigo-600 hover:text-indigo-800 transition">Гардероб</a>
             <a href="{{ path('brand_cities', {_locale: nav_locale}) }}" class="py-2 text-gray-700 hover:text-indigo-600 transition">Города</a>
             <a href="{{ path('brand_styles', {_locale: nav_locale}) }}" class="py-2 text-gray-700 hover:text-indigo-600 transition">Стили</a>
 
@@ -290,7 +290,7 @@
                 <h6 class="text-xs font-bold text-gray-400 uppercase tracking-wider mb-4">О WEARBASE</h6>
                 <ul class="space-y-2">
                     <li><a href="{{ path('about_us', {_locale: nav_locale}) }}" class="text-sm text-gray-400 hover:text-white transition">О нас</a></li>
-                    <li><a href="{{ path('landing_wardrobe', {_locale: nav_locale}) }}" class="text-sm text-gray-400 hover:text-white transition">Гардероб</a></li>
+                    <li><a href="{{ path('landing_wardrobe', {_locale: nav_locale in ['en', 'ru'] ? nav_locale : 'ru'}) }}" class="text-sm text-gray-400 hover:text-white transition">Гардероб</a></li>
                     <li><a href="{{ path('brand_cities', {_locale: nav_locale}) }}" class="text-sm text-gray-400 hover:text-white transition">Бренды по городам</a></li>
                     <li><a href="{{ path('brand_styles', {_locale: nav_locale}) }}" class="text-sm text-gray-400 hover:text-white transition">Бренды по стилям</a></li>
                     <li><a href="{{ path('landing_for_brands', {_locale: nav_locale}) }}" class="text-sm text-gray-400 hover:text-white transition">Для брендов</a></li>

--- a/tests/Controller/WardrobeLandingControllerTest.php
+++ b/tests/Controller/WardrobeLandingControllerTest.php
@@ -18,6 +18,7 @@ class WardrobeLandingControllerTest extends WebTestCase
         self::assertSelectorExists('meta[name="robots"][content="index, follow"]');
         self::assertSelectorExists('link[rel="canonical"][href$="/ru/wardrobe"]');
         self::assertSelectorExists('footer a[href="/ru/wardrobe"]');
+        self::assertCount(2, $crawler->filter('header a[href="/ru/wardrobe"]'));
         self::assertGreaterThanOrEqual(2, $crawler->filter('a[href="/account/wardrobe-app"]')->count());
     }
 }


### PR DESCRIPTION
## Проблема
Пункт «Гардероб» в верхней навигации вёл прямо на защищённый `/account/wardrobe-app`. Гость попадал на авторизацию и не мог сначала открыть публичный лендинг для установки PWA на экран iPhone.

## Исправление
- desktop/mobile пункты «Гардероб» ведут на публичный `/ru/wardrobe`
- авторизация запрашивается только после CTA входа в приложение
- тест фиксирует ссылки в header, footer и CTA

## Проверки
- `php bin/console lint:twig templates/tailwind/base.html.twig`
- `vendor/bin/phpunit tests/Controller/WardrobeLandingControllerTest.php` — 1 test, 9 assertions