### PR TITLE
fix: warm prod container before media migration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,7 @@ jobs:
         run: |
           set -o pipefail
           ssh -i ~/.ssh/deploy_key -p "${P}" -o UserKnownHostsFile=~/.ssh/known_hosts \
-            "${U}@${H}" "cd ${D} && php -d memory_limit=512M bin/console doctrine:migrations:migrate --no-interaction && php bin/console app:wardrobe:migrate-private-media --no-interaction && test ! -d public_html/images/wardrobe && test ! -d public_html/images/wardrobe_drafts && php -d memory_limit=512M bin/console cache:clear --no-debug" \
+            "${U}@${H}" "cd ${D} && php -d memory_limit=512M bin/console doctrine:migrations:migrate --no-interaction && php -d memory_limit=512M bin/console cache:clear --no-debug && php bin/console app:wardrobe:migrate-private-media --no-interaction && test ! -d public_html/images/wardrobe && test ! -d public_html/images/wardrobe_drafts" \
             2>&1 | tee migrate.log
 
       - name: Smoke test


### PR DESCRIPTION
The first rollout correctly stopped before touching media because the old prod container cache did not know the newly deployed command. Clear the Symfony prod cache before invoking the command. No data conflict or deletion occurred.