### PR TITLE
fix: enforce consent for wardrobe photo AI

### DIFF
--- a/docs/tasktracker.md
+++ b/docs/tasktracker.md
@@ -2041,6 +2041,8 @@ SQL-инъекция там, где стоит `(int)`); зато один её 
   batch-filter-before-limit в фоновой команде.
 - [x] Добавить consent/retention: очистка abandoned drafts и диагностического `ai_raw`, EXIF strip,
   лимит хранилища и rate limit стоимости vision.
+- [x] Закрыть legacy AI-photo endpoint тем же consent/sanitization boundary: явное согласие,
+  parent grant для child, строгая image validation, EXIF re-encode и subject-aware AI context.
 - [x] Перенести legacy `/images/wardrobe*` в private storage идемпотентной deploy-командой;
   после успешного переноса публичные каталоги удаляются, конфликтующие файлы останавливают деплой.
 - [ ] Добавить IndexedDB retry только как foreground-resume при следующем online/open; не обещать

--- a/src/Controller/Account/WardrobeController.php
+++ b/src/Controller/Account/WardrobeController.php
@@ -12,6 +12,7 @@ use App\Entity\WardrobeItemPhoto;
 use App\Entity\WardrobeTransfer;
 use App\Form\Account\WardrobeItemFormType;
 use App\Repository\WardrobeItemRepository;
+use App\Repository\WardrobeConsentRepository;
 use App\Repository\WardrobeTransferRepository;
 use App\Repository\WardrobeItemLifecycleEventRepository;
 use App\Service\AiUsageTracker;
@@ -22,6 +23,7 @@ use App\Service\Wardrobe\WardrobePhotoManager;
 use App\Service\Wardrobe\WardrobeRemotePhotoFetcher;
 use App\Service\Wardrobe\WardrobeStatisticsService;
 use App\Service\Wardrobe\WardrobeImageSanitizer;
+use App\Service\Wardrobe\WardrobeConsentService;
 use App\Service\Wardrobe\WardrobeWearService;
 use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use Doctrine\ORM\EntityManagerInterface;
@@ -36,6 +38,8 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\RateLimiter\RateLimiterFactory;
 use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Validator\Constraints\Image;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
 use Vich\UploaderBundle\Storage\StorageInterface;
 
 #[Route('/account/wardrobe', name: 'account_wardrobe_')]
@@ -351,6 +355,9 @@ class WardrobeController extends AbstractController
         StorageInterface $vichStorage,
         AiUsageTracker $usageTracker,
         LoggerInterface $wardrobeAiLogger,
+        ValidatorInterface $validator,
+        WardrobeConsentRepository $consents,
+        WardrobeConsentService $consentService,
     ): JsonResponse {
         if (!$this->isCsrfTokenValid('wardrobe_ai', (string) $request->request->get('_token'))) {
             return $this->json(['ok' => false, 'error' => 'Недействительный токен'], Response::HTTP_BAD_REQUEST);
@@ -369,14 +376,24 @@ class WardrobeController extends AbstractController
             if (!$photo instanceof UploadedFile || !$photo->isValid()) {
                 return $this->json(['ok' => false, 'error' => 'Файл не получен'], Response::HTTP_BAD_REQUEST);
             }
-            if (!str_starts_with((string) $photo->getMimeType(), 'image/')) {
-                return $this->json(['ok' => false, 'error' => 'Нужен файл изображения'], Response::HTTP_BAD_REQUEST);
+            if ($error = $this->validateAiPhoto($photo, $validator)) {
+                return $error;
             }
-            if ($photo->getSize() > 10 * 1024 * 1024) {
-                return $this->json(['ok' => false, 'error' => 'Файл больше 10 МБ'], Response::HTTP_BAD_REQUEST);
+            if ($error = $this->photoConsentError($request, $user, $user, $consents, $consentService)) {
+                return $error;
             }
 
-            $result = $ai->suggestFromPhoto($photo->getPathname(), $user);
+            try {
+                $sanitized = $this->imageSanitizer->sanitize($photo);
+                $result = $ai->suggestFromPhoto($sanitized->getPathname(), $user);
+            } catch (\InvalidArgumentException $exception) {
+                return $this->json(['ok' => false, 'error' => $exception->getMessage()], Response::HTTP_UNPROCESSABLE_ENTITY);
+            } finally {
+                if (isset($sanitized) && is_file($sanitized->getPathname())) {
+                    @unlink($sanitized->getPathname());
+                }
+            }
+
             return $this->json($result, $result['ok'] ? Response::HTTP_OK : Response::HTTP_BAD_REQUEST);
         }
 
@@ -399,10 +416,65 @@ class WardrobeController extends AbstractController
         if ($absPath === null || !is_file($absPath)) {
             return $this->json(['ok' => false, 'error' => 'Файл фото не найден'], Response::HTTP_BAD_REQUEST);
         }
+        $subject = $item->getUser();
+        if ($error = $this->photoConsentError($request, $user, $subject, $consents, $consentService)) {
+            return $error;
+        }
 
-        $result = $ai->suggestFromPhoto($absPath, $user);
+        $savedPhoto = new UploadedFile($absPath, basename($absPath), (string) mime_content_type($absPath), null, true);
+        if ($error = $this->validateAiPhoto($savedPhoto, $validator)) {
+            return $error;
+        }
+
+        try {
+            $sanitized = $this->imageSanitizer->sanitize($savedPhoto);
+            $result = $ai->suggestFromPhoto($sanitized->getPathname(), $subject);
+        } catch (\InvalidArgumentException $exception) {
+            return $this->json(['ok' => false, 'error' => $exception->getMessage()], Response::HTTP_UNPROCESSABLE_ENTITY);
+        } finally {
+            if (isset($sanitized) && is_file($sanitized->getPathname())) {
+                @unlink($sanitized->getPathname());
+            }
+        }
 
         return $this->json($result, $result['ok'] ? Response::HTTP_OK : Response::HTTP_BAD_REQUEST);
+    }
+
+    private function validateAiPhoto(UploadedFile $photo, ValidatorInterface $validator): ?JsonResponse
+    {
+        $violations = $validator->validate($photo, new Image([
+            'maxSize' => '10M',
+            'mimeTypes' => ['image/jpeg', 'image/png', 'image/webp'],
+            'maxWidth' => 5000,
+            'maxHeight' => 5000,
+        ]));
+
+        return $violations->count() === 0
+            ? null
+            : $this->json(['ok' => false, 'error' => $violations->get(0)->getMessage()], Response::HTTP_UNPROCESSABLE_ENTITY);
+    }
+
+    private function photoConsentError(
+        Request $request,
+        User $actor,
+        User $subject,
+        WardrobeConsentRepository $consents,
+        WardrobeConsentService $consentService,
+    ): ?JsonResponse {
+        if ($consents->findForSubject($subject)?->isPhotoProcessingGranted()) {
+            return null;
+        }
+        if (!$request->request->getBoolean('photoConsent')) {
+            return $this->json(['ok' => false, 'error' => 'Подтвердите согласие на приватную обработку фото'], Response::HTTP_UNPROCESSABLE_ENTITY);
+        }
+
+        try {
+            $consentService->grantPhotoProcessing($actor, $subject);
+        } catch (\Symfony\Component\Security\Core\Exception\AccessDeniedException $exception) {
+            return $this->json(['ok' => false, 'error' => $exception->getMessage()], Response::HTTP_FORBIDDEN);
+        }
+
+        return null;
     }
 
     /**

--- a/templates/account/wardrobe/form.html.twig
+++ b/templates/account/wardrobe/form.html.twig
@@ -86,6 +86,10 @@
             {% endif %}
         </div>
     {% endif %}
+    <label class="mb-3 flex items-start gap-2 rounded-xl bg-slate-50 p-3 text-xs text-slate-600">
+        <input id="wardrobe-ai-photo-consent" type="checkbox" class="mt-0.5 h-4 w-4 rounded">
+        <span>Разрешаю приватную обработку выбранного фото для AI-подсказок. Для детского профиля согласие подтверждает родитель.</span>
+    </label>
     {{ form_widget(form.photoFile, {'attr': {'class': 'block w-full text-sm text-gray-600 file:mr-3 file:rounded-lg file:border-0 file:bg-gray-900 file:px-4 file:py-2 file:text-sm file:font-semibold file:text-white hover:file:bg-black'}}) }}
     {{ f.err(form.photoFile) }}
     <div class="mt-4">
@@ -230,6 +234,7 @@
 
     // ── Фото-флоу ──
     var photoInput = document.querySelector('#wardrobe-photo-section input[type="file"]');
+    var photoConsent = document.getElementById('wardrobe-ai-photo-consent');
     var photoStatus = document.getElementById('wardrobe-ai-photo-status');
 
     if (photoInput && photoStatus) {
@@ -248,6 +253,7 @@
             var fd = new FormData();
             fd.append('photo', file);
             fd.append('_token', CSRF_TOKEN);
+            if (photoConsent && photoConsent.checked) fd.append('photoConsent', '1');
 
             fetch(PHOTO_URL, { method: 'POST', body: fd, credentials: 'same-origin', signal: controller.signal })
                 .then(readJson)
@@ -385,10 +391,13 @@
                 var fd = new FormData();
                 fd.append('photo', file);
                 fd.append('_token', CSRF_TOKEN);
+                if (photoConsent && photoConsent.checked) fd.append('photoConsent', '1');
                 reqPromise = requestAiPhoto(fd);
             } else {
+                var savedParams = new URLSearchParams({ item_id: ITEM_ID, _token: CSRF_TOKEN });
+                if (photoConsent && photoConsent.checked) savedParams.append('photoConsent', '1');
                 reqPromise = requestAiPhoto(
-                    new URLSearchParams({ item_id: ITEM_ID, _token: CSRF_TOKEN }),
+                    savedParams,
                     { 'Content-Type': 'application/x-www-form-urlencoded' }
                 );
             }

--- a/tests/Controller/WardrobeControllerTest.php
+++ b/tests/Controller/WardrobeControllerTest.php
@@ -1820,12 +1820,15 @@ class WardrobeControllerTest extends AuthenticatedWebTestCase
         $storage = static::getContainer()->get(StorageInterface::class);
         $absPath = $storage->resolvePath($item, 'photoFile');
         @mkdir(dirname($absPath), 0777, true);
-        file_put_contents($absPath, 'fake-image-bytes');
+        copy($this->makeTempImage(), $absPath);
 
         $aiMock = $this->createMock(WardrobeAiService::class);
         $aiMock->expects($this->once())
             ->method('suggestFromPhoto')
-            ->with($absPath, $this->callback(static fn (User $u): bool => $u->getId() === $user->getId()))
+            ->with(
+                $this->callback(static fn (string $path): bool => $path !== $absPath && is_file($path) && mime_content_type($path) === 'image/jpeg'),
+                $this->callback(static fn (User $u): bool => $u->getId() === $user->getId()),
+            )
             ->willReturn(['ok' => true, 'fields' => ['category' => 'Обувь'], 'confidence' => 'high']);
         static::getContainer()->set(WardrobeAiService::class, $aiMock);
 
@@ -1836,6 +1839,7 @@ class WardrobeControllerTest extends AuthenticatedWebTestCase
             $client->request('POST', '/account/wardrobe/ai/photo', [
                 'item_id' => (string) $item->getId(),
                 '_token'  => $token,
+                'photoConsent' => '1',
             ]);
 
             $this->assertResponseIsSuccessful();
@@ -1845,6 +1849,52 @@ class WardrobeControllerTest extends AuthenticatedWebTestCase
         } finally {
             @unlink($absPath);
         }
+    }
+
+    public function testAiPhotoRequiresExplicitConsentAndParentGrantForChild(): void
+    {
+        $client = static::createClient();
+        $client->disableReboot();
+        $parent = UserFactory::withEmail(static::getContainer(), 'ai-consent-parent-'.bin2hex(random_bytes(4)).'@test.local');
+        /** @var FamilyService $families */
+        $families = static::getContainer()->get(FamilyService::class);
+        $child = $families->createChild($parent, 'Лена');
+        $client->loginUser($child);
+
+        $aiMock = $this->createMock(WardrobeAiService::class);
+        $aiMock->expects($this->never())->method('suggestFromPhoto');
+        static::getContainer()->set(WardrobeAiService::class, $aiMock);
+
+        $client->request('GET', '/account/wardrobe');
+        $token = $this->forceCsrfToken($client->getRequest(), 'wardrobe_ai');
+        $photo = new UploadedFile($this->makeTempImage(), 'child.png', 'image/png', null, true);
+        $client->request('POST', '/account/wardrobe/ai/photo', [
+            '_token' => $token,
+            'photoConsent' => '1',
+        ], ['photo' => $photo]);
+
+        $this->assertResponseStatusCodeSame(403);
+        $data = json_decode($client->getResponse()->getContent(), true);
+        $this->assertStringContainsString('согласие родителя', $data['error']);
+    }
+
+    public function testAiPhotoRejectsUnconsentedAdultUploadBeforeCallingAi(): void
+    {
+        $client = static::createClient();
+        $client->disableReboot();
+        $client->loginUser(UserFactory::withEmail(static::getContainer(), 'ai-consent-adult-'.bin2hex(random_bytes(4)).'@test.local'));
+        $aiMock = $this->createMock(WardrobeAiService::class);
+        $aiMock->expects($this->never())->method('suggestFromPhoto');
+        static::getContainer()->set(WardrobeAiService::class, $aiMock);
+
+        $client->request('GET', '/account/wardrobe');
+        $token = $this->forceCsrfToken($client->getRequest(), 'wardrobe_ai');
+        $photo = new UploadedFile($this->makeTempImage(), 'adult.png', 'image/png', null, true);
+        $client->request('POST', '/account/wardrobe/ai/photo', ['_token' => $token], ['photo' => $photo]);
+
+        $this->assertResponseStatusCodeSame(422);
+        $data = json_decode($client->getResponse()->getContent(), true);
+        $this->assertStringContainsString('Подтвердите согласие', $data['error']);
     }
 
     /**


### PR DESCRIPTION
## Summary
- apply the same explicit photo-processing consent boundary to the legacy AI-photo endpoint
- require a parent grant for child profiles
- validate dimensions/MIME, re-encode images and strip metadata before every AI call
- pass the profile subject, not the parent actor, into AI context
- expose a clear consent control in the mobile wardrobe form

## Verification
- 77 wardrobe PHPUnit tests, 440 assertions
- explicit adult no-consent and child self-grant denial tests with zero AI calls
- PHP/Twig/Doctrine mapping/diff checks passed