### PR TITLE
fix: remove stale static PWA manifest on deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,8 @@ jobs:
               -e "ssh -i ~/.ssh/deploy_key -p ${P} -o UserKnownHostsFile=~/.ssh/known_hosts" \
               "./$DIR/" "${U}@${H}:${D}/$DIR/"
           done
+          ssh -i ~/.ssh/deploy_key -p "${P}" -o UserKnownHostsFile=~/.ssh/known_hosts \
+            "${U}@${H}" "rm -f '${D}/public_html/manifest.webmanifest'"
 
       - name: Migrate + clear cache
         id: migrate


### PR DESCRIPTION
Удаляет оставшийся на production статический manifest.webmanifest перед cache clear, чтобы запрос обслуживал Symfony-контроллер с корректным application/manifest+json MIME.\n\nПроверка: git diff --check; production probe after merge.