### PR TITLE
feat(wardrobe): add ingest operations health check

### DIFF
--- a/config/packages/vich_uploader.yaml
+++ b/config/packages/vich_uploader.yaml
@@ -87,7 +87,7 @@ vich_uploader:
 
         wardrobe_draft_photo:
             uri_prefix: /account/wardrobe/media/draft
-            upload_destination: '%kernel.project_dir%/var/uploads/wardrobe_drafts'
+            upload_destination: '%app.wardrobe_draft_storage_dir%'
             namer: Vich\UploaderBundle\Naming\SmartUniqueNamer
             directory_namer:
                 service: Vich\UploaderBundle\Naming\SubdirDirectoryNamer

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -6,6 +6,7 @@
 parameters:
     app.admin_email: '%env(ADMIN_EMAIL)%'
     app.telegram_bot_username: 'wearbase_bot'
+    app.wardrobe_draft_storage_dir: '%kernel.project_dir%/var/uploads/wardrobe_drafts'
     # Дефолты опциональных env (чтобы приложение грузилось без записи в .env)
     env(ADMIN_TELEGRAM_CHAT_ID): ''
     env(VK_APP_ID): ''
@@ -157,6 +158,10 @@ services:
             $visionModel: '%env(WARDROBE_VISION_MODEL)%'
             $visionLocal: '%env(bool:WARDROBE_VISION_LOCAL)%'
             $localModel: '%env(LOCAL_LLM_MODEL)%'
+
+    App\Service\Wardrobe\WardrobeIngestHealth:
+        arguments:
+            $storageDir: '%app.wardrobe_draft_storage_dir%'
 
     App\Service\Wardrobe\WardrobeOutfitService:
         arguments:

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -129,6 +129,7 @@ cp ops/com.wearbase.cron.plist ~/Library/LaunchAgents/ \
 |---|---|---|---|
 | `app:wardrobe:ingest-drafts` | Фоновое vision-распознавание приватных batch-drafts с lease/retry. | ⏰ `*/2 * * * *` | ☁️ prod |
 | `app:wardrobe:cleanup-drafts` | Через 7 дней очищает photo/`ai_raw` accepted receipts; через 30 дней удаляет abandoned drafts. `--dry-run`. | ⏰ `17 3 * * *` | ☁️ prod |
+| `app:wardrobe:ingest-health` | Очередь, oldest pending, expired lease, failed/retry, storage и последний scheduler run. `--json`, `--check`. Подробнее: [операционная проверка](wardrobe_ingest_operations.md). | 👆 smoke/monitoring | ☁️ prod |
 | `app:contacts:refresh` | Актуализация контактов из RAG-корпуса (новый конвейер, см. `_docs/contacts-refresh-plan.md`). TTL-ревалидация, демон-режим. | ⏰/🔁 | 🖥 .43 |
 | `app:brand:enrich-contacts` | **Легаси**: разовое обогащение из скрейп-корпуса (27b). Терминальные статусы, HTTP-проверка URL. Вытесняется `contacts:refresh`. | ⏰ `*/10` (пока) | 🖥 .43 |
 

--- a/docs/wardrobe_ingest_operations.md
+++ b/docs/wardrobe_ingest_operations.md
@@ -1,0 +1,42 @@
+# Авто-ингест гардероба: операционная проверка
+
+Очередь фото проверяется без запуска vision-модели:
+
+```bash
+php bin/console app:wardrobe:ingest-health
+php bin/console app:wardrobe:ingest-health --json
+php bin/console app:wardrobe:ingest-health --check
+```
+
+`--check` возвращает ненулевой код только при `critical`: каталог приватных загрузок отсутствует
+или недоступен для записи либо последний запуск scheduler завершился с ошибкой. Наличие retry,
+failed или истёкших lease отображается как `warning`: истёкший lease штатно забирается следующим
+worker-проходом, поэтому сам по себе не означает аварию.
+
+Команда показывает:
+
+- число pending и возраст самого старого pending;
+- истёкшие processing lease;
+- failed и pending, уже возвращённые на retry;
+- объём файлов по сохранённому `file_size`, доступность каталога для записи и свободное место;
+- состояние строки `scheduled_command`, время и exit code последнего запуска worker.
+
+## Production smoke
+
+После деплоя и миграций:
+
+```bash
+APP_ENV=prod php bin/console app:wardrobe:ingest-health --check --no-debug
+APP_ENV=prod php bin/console app:wardrobe:ingest-health --json --no-debug
+```
+
+Проверить, что `storage_writable=true`, `scheduler_configured=true`, последний exit code равен `0`,
+а возраст oldest pending уменьшается после очередного двухминутного запуска. При expired lease
+повторить команду после следующего тика: счётчик должен обнулиться или запись должна перейти в retry/failed.
+
+## Ограничение данных scheduler
+
+`scheduled_command` хранит только последний запуск. Поэтому `scheduler_last_success_at` достоверен,
+только если последний exit code равен `0`. После неуспешного запуска прежнее время успеха восстановить
+невозможно: команда возвращает `scheduler_last_success_known=false`, не подставляя вымышленное значение.
+Исторический last-success потребует отдельного журнала запусков и не входит в этот атомарный блок.

--- a/src/Command/Wardrobe/WardrobeIngestHealthCommand.php
+++ b/src/Command/Wardrobe/WardrobeIngestHealthCommand.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Command\Wardrobe;
+
+use App\Service\Wardrobe\WardrobeIngestHealth;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand(name: 'app:wardrobe:ingest-health', description: 'Операционное состояние очереди распознавания гардероба')]
+final class WardrobeIngestHealthCommand extends Command
+{
+    public function __construct(private readonly WardrobeIngestHealth $health)
+    {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('json', null, InputOption::VALUE_NONE, 'Вывести machine-readable JSON')
+            ->addOption('check', null, InputOption::VALUE_NONE, 'Вернуть ненулевой exit code при critical');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $snapshot = $this->health->snapshot();
+        if ($input->getOption('json')) {
+            $output->writeln(json_encode($snapshot, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES));
+        } else {
+            $io = new SymfonyStyle($input, $output);
+            $io->title('Wardrobe ingest health');
+            $io->table(['Metric', 'Value'], array_map(
+                static fn (string $key, mixed $value): array => [$key, match (true) {
+                    $value === null => 'unknown',
+                    is_bool($value) => $value ? 'yes' : 'no',
+                    default => (string) $value,
+                }],
+                array_keys($snapshot),
+                array_values($snapshot),
+            ));
+        }
+
+        return $input->getOption('check') && $snapshot['status'] === 'critical' ? Command::FAILURE : Command::SUCCESS;
+    }
+}

--- a/src/Repository/ScheduledCommandRepository.php
+++ b/src/Repository/ScheduledCommandRepository.php
@@ -23,4 +23,14 @@ class ScheduledCommandRepository extends ServiceEntityRepository
     {
         return $this->findBy(['enabled' => true, 'environment' => $environment], ['id' => 'ASC']);
     }
+
+    public function findWardrobeIngestWorker(): ?ScheduledCommand
+    {
+        return $this->createQueryBuilder('c')
+            ->andWhere('c.command LIKE :command')
+            ->setParameter('command', 'app:wardrobe:ingest-drafts%')
+            ->setMaxResults(1)
+            ->getQuery()
+            ->getOneOrNullResult();
+    }
 }

--- a/src/Repository/WardrobeItemDraftRepository.php
+++ b/src/Repository/WardrobeItemDraftRepository.php
@@ -135,6 +135,38 @@ class WardrobeItemDraftRepository extends ServiceEntityRepository
             ->getQuery()->getSingleScalarResult();
     }
 
+    /**
+     * Operational counters for the asynchronous ingest worker.
+     *
+     * @return array{pending:int,oldestPendingAt:?\DateTimeInterface,expiredLeases:int,failed:int,retrying:int,storageBytes:int}
+     */
+    public function operationalSnapshot(\DateTimeImmutable $now): array
+    {
+        $pending = (int) $this->count(['status' => WardrobeItemDraft::STATUS_PENDING]);
+        $oldest = $this->createQueryBuilder('d')
+            ->select('MIN(d.createdAt)')
+            ->andWhere('d.status = :status')
+            ->setParameter('status', WardrobeItemDraft::STATUS_PENDING)
+            ->getQuery()
+            ->getSingleScalarResult();
+
+        return [
+            'pending' => $pending,
+            'oldestPendingAt' => is_string($oldest) ? new \DateTimeImmutable($oldest) : null,
+            'expiredLeases' => (int) $this->createQueryBuilder('d')->select('COUNT(d.id)')
+                ->andWhere('d.status = :status')->andWhere('d.leaseUntil < :now')
+                ->setParameter('status', WardrobeItemDraft::STATUS_PROCESSING)->setParameter('now', $now)
+                ->getQuery()->getSingleScalarResult(),
+            'failed' => (int) $this->count(['status' => WardrobeItemDraft::STATUS_FAILED]),
+            'retrying' => (int) $this->createQueryBuilder('d')->select('COUNT(d.id)')
+                ->andWhere('d.status = :status')->andWhere('d.attempts > 0')
+                ->setParameter('status', WardrobeItemDraft::STATUS_PENDING)
+                ->getQuery()->getSingleScalarResult(),
+            'storageBytes' => (int) $this->createQueryBuilder('d')->select('COALESCE(SUM(d.fileSize), 0)')
+                ->andWhere('d.photo IS NOT NULL')->getQuery()->getSingleScalarResult(),
+        ];
+    }
+
     /** @return WardrobeItemDraft[] */
     public function findAcceptedBefore(\DateTimeImmutable $before, int $limit = 100): array
     {

--- a/src/Service/Wardrobe/WardrobeIngestHealth.php
+++ b/src/Service/Wardrobe/WardrobeIngestHealth.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Wardrobe;
+
+use App\Repository\ScheduledCommandRepository;
+use App\Repository\WardrobeItemDraftRepository;
+
+final class WardrobeIngestHealth
+{
+    public function __construct(
+        private readonly WardrobeItemDraftRepository $drafts,
+        private readonly ScheduledCommandRepository $scheduledCommands,
+        private readonly string $storageDir,
+    ) {}
+
+    /** @return array<string, bool|int|string|null> */
+    public function snapshot(?\DateTimeImmutable $now = null): array
+    {
+        $now ??= new \DateTimeImmutable();
+        $drafts = $this->drafts->operationalSnapshot($now);
+        $scheduler = $this->scheduledCommands->findWardrobeIngestWorker();
+        $lastRun = $scheduler?->getLastRunAt();
+        $lastExitCode = $scheduler?->getLastExitCode();
+        $storageExists = is_dir($this->storageDir);
+        $storageWritable = $storageExists && is_writable($this->storageDir);
+
+        $status = 'ok';
+        if (!$storageWritable || ($lastExitCode !== null && $lastExitCode !== 0)) {
+            $status = 'critical';
+        } elseif ($drafts['expiredLeases'] > 0
+            || $drafts['retrying'] > 0
+            || $drafts['failed'] > 0
+            || $scheduler === null
+            || !$scheduler->isEnabled()
+            || $lastRun === null
+        ) {
+            $status = 'warning';
+        }
+
+        return [
+            'status' => $status,
+            'pending' => $drafts['pending'],
+            'oldest_pending_at' => $drafts['oldestPendingAt']?->format(DATE_ATOM),
+            'oldest_pending_age_seconds' => $drafts['oldestPendingAt'] === null ? null : max(0, $now->getTimestamp() - $drafts['oldestPendingAt']->getTimestamp()),
+            'expired_leases' => $drafts['expiredLeases'],
+            'failed' => $drafts['failed'],
+            'retrying' => $drafts['retrying'],
+            'storage_path' => $this->storageDir,
+            'storage_exists' => $storageExists,
+            'storage_writable' => $storageWritable,
+            'storage_usage_bytes' => $drafts['storageBytes'],
+            'storage_free_bytes' => $storageExists ? $this->diskFreeSpace($this->storageDir) : null,
+            'scheduler_configured' => $scheduler !== null,
+            'scheduler_enabled' => $scheduler?->isEnabled(),
+            'scheduler_last_run_at' => $lastRun?->format(DATE_ATOM),
+            'scheduler_last_run_age_seconds' => $lastRun === null ? null : max(0, $now->getTimestamp() - $lastRun->getTimestamp()),
+            'scheduler_last_exit_code' => $lastExitCode,
+            'scheduler_last_success_at' => $lastExitCode === 0 ? $lastRun?->format(DATE_ATOM) : null,
+            'scheduler_last_success_known' => $lastExitCode === 0,
+        ];
+    }
+
+    private function diskFreeSpace(string $path): ?int
+    {
+        $bytes = @disk_free_space($path);
+
+        return $bytes === false ? null : (int) $bytes;
+    }
+}

--- a/tests/Command/WardrobeIngestHealthCommandTest.php
+++ b/tests/Command/WardrobeIngestHealthCommandTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Command;
+
+use App\Command\Wardrobe\WardrobeIngestHealthCommand;
+use App\Repository\ScheduledCommandRepository;
+use App\Repository\WardrobeItemDraftRepository;
+use App\Service\Wardrobe\WardrobeIngestHealth;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+final class WardrobeIngestHealthCommandTest extends TestCase
+{
+    public function testJsonCheckReturnsFailureForCriticalSnapshot(): void
+    {
+        $drafts = $this->createMock(WardrobeItemDraftRepository::class);
+        $drafts->method('operationalSnapshot')->willReturn([
+            'pending' => 0,
+            'oldestPendingAt' => null,
+            'expiredLeases' => 0,
+            'failed' => 0,
+            'retrying' => 0,
+            'storageBytes' => 0,
+        ]);
+        $scheduled = $this->createMock(ScheduledCommandRepository::class);
+        $scheduled->method('findWardrobeIngestWorker')->willReturn(null);
+        $health = new WardrobeIngestHealth($drafts, $scheduled, '/path/that/does/not/exist');
+        $tester = new CommandTester(new WardrobeIngestHealthCommand($health));
+
+        $exit = $tester->execute(['--json' => true, '--check' => true]);
+        $payload = json_decode(trim($tester->getDisplay()), true, flags: JSON_THROW_ON_ERROR);
+
+        self::assertSame(Command::FAILURE, $exit);
+        self::assertSame('critical', $payload['status']);
+        self::assertFalse($payload['storage_writable']);
+        self::assertFalse($payload['scheduler_configured']);
+    }
+}

--- a/tests/Repository/WardrobeIngestHealthRepositoryTest.php
+++ b/tests/Repository/WardrobeIngestHealthRepositoryTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Repository;
+
+use App\Entity\ScheduledCommand;
+use App\Entity\WardrobeItemDraft;
+use App\Repository\ScheduledCommandRepository;
+use App\Repository\WardrobeItemDraftRepository;
+use App\Tests\Controller\UserFactory;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+final class WardrobeIngestHealthRepositoryTest extends KernelTestCase
+{
+    public function testOperationalSnapshotUsesPersistedQueueState(): void
+    {
+        self::bootKernel();
+        $container = self::getContainer();
+        $em = $container->get('doctrine.orm.entity_manager');
+        $user = UserFactory::withEmail($container, 'ingest-health-repository@test.local');
+        $now = new \DateTimeImmutable();
+        /** @var WardrobeItemDraftRepository $drafts */
+        $drafts = $container->get(WardrobeItemDraftRepository::class);
+        $before = $drafts->operationalSnapshot($now);
+
+        $pending = (new WardrobeItemDraft())->setUser($user)->setBatchId('health-pending')->setPhoto('pending.jpg')->setFileSize(100);
+        $retrying = (new WardrobeItemDraft())->setUser($user)->setBatchId('health-retry')->setPhoto('retry.jpg')->setFileSize(200);
+        $retrying->claim('worker', $now->modify('+5 minutes'));
+        $retrying->releaseForRetry('temporary');
+        $expired = (new WardrobeItemDraft())->setUser($user)->setBatchId('health-expired')->setPhoto('expired.jpg')->setFileSize(300);
+        $expired->claim('dead-worker', $now->modify('-1 minute'));
+        $failed = (new WardrobeItemDraft())->setUser($user)->setBatchId('health-failed')->setStatus(WardrobeItemDraft::STATUS_FAILED);
+        foreach ([$pending, $retrying, $expired, $failed] as $draft) {
+            $em->persist($draft);
+        }
+        /** @var ScheduledCommandRepository $scheduled */
+        $scheduled = $container->get(ScheduledCommandRepository::class);
+        $job = $scheduled->findWardrobeIngestWorker();
+        if ($job === null) {
+            $job = (new ScheduledCommand())->setEnvironment('prod')->setName('ingest')
+                ->setCommand('app:wardrobe:ingest-drafts --no-debug')->setSchedule('*/2 * * * *');
+            $em->persist($job);
+        }
+        $em->flush();
+
+        $snapshot = $drafts->operationalSnapshot($now);
+
+        self::assertSame($before['pending'] + 2, $snapshot['pending']);
+        self::assertSame($before['retrying'] + 1, $snapshot['retrying']);
+        self::assertSame($before['expiredLeases'] + 1, $snapshot['expiredLeases']);
+        self::assertSame($before['failed'] + 1, $snapshot['failed']);
+        self::assertSame($before['storageBytes'] + 600, $snapshot['storageBytes']);
+        self::assertNotNull($snapshot['oldestPendingAt']);
+        self::assertSame($job->getId(), $scheduled->findWardrobeIngestWorker()?->getId());
+    }
+}

--- a/tests/Service/Wardrobe/WardrobeIngestHealthTest.php
+++ b/tests/Service/Wardrobe/WardrobeIngestHealthTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Service\Wardrobe;
+
+use App\Entity\ScheduledCommand;
+use App\Repository\ScheduledCommandRepository;
+use App\Repository\WardrobeItemDraftRepository;
+use App\Service\Wardrobe\WardrobeIngestHealth;
+use PHPUnit\Framework\TestCase;
+
+final class WardrobeIngestHealthTest extends TestCase
+{
+    private string $storageDir;
+
+    protected function setUp(): void
+    {
+        $this->storageDir = sys_get_temp_dir().'/wardrobe-health-'.bin2hex(random_bytes(4));
+        mkdir($this->storageDir);
+    }
+
+    protected function tearDown(): void
+    {
+        @rmdir($this->storageDir);
+    }
+
+    public function testSnapshotReportsQueueStorageAndSuccessfulLastRun(): void
+    {
+        $now = new \DateTimeImmutable('2026-08-24T12:00:00+03:00');
+        $drafts = $this->createMock(WardrobeItemDraftRepository::class);
+        $drafts->method('operationalSnapshot')->with($now)->willReturn([
+            'pending' => 2,
+            'oldestPendingAt' => $now->modify('-5 minutes'),
+            'expiredLeases' => 0,
+            'failed' => 0,
+            'retrying' => 0,
+            'storageBytes' => 4096,
+        ]);
+        $job = (new ScheduledCommand())
+            ->setName('ingest')->setCommand('app:wardrobe:ingest-drafts --no-debug')->setSchedule('*/2 * * * *')
+            ->setLastRunAt(\DateTime::createFromImmutable($now->modify('-1 minute')))
+            ->setLastExitCode(0);
+        $scheduled = $this->createMock(ScheduledCommandRepository::class);
+        $scheduled->method('findWardrobeIngestWorker')->willReturn($job);
+
+        $snapshot = (new WardrobeIngestHealth($drafts, $scheduled, $this->storageDir))->snapshot($now);
+
+        self::assertSame('ok', $snapshot['status']);
+        self::assertSame(300, $snapshot['oldest_pending_age_seconds']);
+        self::assertSame(4096, $snapshot['storage_usage_bytes']);
+        self::assertTrue($snapshot['storage_writable']);
+        self::assertTrue($snapshot['scheduler_last_success_known']);
+        self::assertSame(60, $snapshot['scheduler_last_run_age_seconds']);
+        self::assertSame('2026-08-24T11:59:00+03:00', $snapshot['scheduler_last_success_at']);
+    }
+
+    public function testFailedLastRunAndMissingStorageAreCriticalWithoutInventingPreviousSuccess(): void
+    {
+        $drafts = $this->createMock(WardrobeItemDraftRepository::class);
+        $drafts->method('operationalSnapshot')->willReturn([
+            'pending' => 1,
+            'oldestPendingAt' => null,
+            'expiredLeases' => 1,
+            'failed' => 3,
+            'retrying' => 1,
+            'storageBytes' => 0,
+        ]);
+        $job = (new ScheduledCommand())
+            ->setName('ingest')->setCommand('app:wardrobe:ingest-drafts --no-debug')->setSchedule('*/2 * * * *')
+            ->setLastRunAt(new \DateTime('2026-08-24T11:00:00+03:00'))
+            ->setLastExitCode(1);
+        $scheduled = $this->createMock(ScheduledCommandRepository::class);
+        $scheduled->method('findWardrobeIngestWorker')->willReturn($job);
+
+        $snapshot = (new WardrobeIngestHealth($drafts, $scheduled, $this->storageDir.'/missing'))->snapshot();
+
+        self::assertSame('critical', $snapshot['status']);
+        self::assertFalse($snapshot['storage_exists']);
+        self::assertFalse($snapshot['storage_writable']);
+        self::assertFalse($snapshot['scheduler_last_success_known']);
+        self::assertNull($snapshot['scheduler_last_success_at']);
+    }
+}


### PR DESCRIPTION
## Summary
- add `app:wardrobe:ingest-health` human and JSON reports for backlog, leases, retries/failures, storage and scheduler state
- add `--check` critical exit semantics for production smoke/monitoring
- document production smoke and the honest last-success data gap

## Tests
- `APP_ENV=test php -d memory_limit=512M vendor/bin/phpunit tests/Controller/WardrobeIngestControllerTest.php tests/Command/CleanupWardrobeDraftsCommandTest.php tests/Entity/WardrobeItemDraftLeaseTest.php tests/Repository/WardrobeItemDraftRepositoryTest.php tests/Repository/WardrobeIngestHealthRepositoryTest.php tests/Service/Wardrobe/WardrobeIngestHealthTest.php tests/Command/WardrobeIngestHealthCommandTest.php`
- `APP_ENV=test php -d memory_limit=512M bin/console lint:container`
- local CLI smoke with `--json` and `--check`

## Data limitation
`scheduled_command` retains only the latest run. The command reports `scheduler_last_success_at` only when that latest run exited 0; after a failed latest run it returns `scheduler_last_success_known=false` rather than inventing historical success. IndexedDB is intentionally out of scope.