### PR TITLE
feat: notify parents about child purchase outcomes

### DIFF
--- a/migrations/Version20260824_family_purchase_notifications.php
+++ b/migrations/Version20260824_family_purchase_notifications.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260824_family_purchase_notifications extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add idempotency key for family purchase in-app notifications';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE notification ADD dedupe_key VARCHAR(100) DEFAULT NULL');
+        $this->addSql('CREATE UNIQUE INDEX uniq_notification_recipient_dedupe ON notification (recipient_id, dedupe_key)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX uniq_notification_recipient_dedupe ON notification');
+        $this->addSql('ALTER TABLE notification DROP dedupe_key');
+    }
+}

--- a/src/Controller/Account/NotificationController.php
+++ b/src/Controller/Account/NotificationController.php
@@ -26,6 +26,10 @@ class NotificationController extends AbstractController
         Notification::TYPE_SYSTEM => 'Системные',
         Notification::TYPE_PURCHASE_REQUEST_NEW => 'Новый запрос на покупку',
         Notification::TYPE_PURCHASE_REQUEST_DECIDED => 'Решение по покупке',
+        Notification::TYPE_PURCHASE_FITTING => 'Результат примерки',
+        Notification::TYPE_PURCHASE_BOUGHT => 'Вещь выкуплена',
+        Notification::TYPE_PURCHASE_REFUSED => 'Отказ после примерки',
+        Notification::TYPE_PURCHASE_RETURNED => 'Вещь возвращена',
     ];
 
     private const CHANNELS = ['channelEmail', 'channelInapp'];
@@ -36,10 +40,10 @@ class NotificationController extends AbstractController
         /** @var User $user */
         $user = $this->getUser();
 
-        return $this->render('account/notifications.html.twig', [
+        return $this->privateResponse($this->render('account/notifications.html.twig', [
             'notifications' => $repo->findForUser($user),
             'unreadCount'   => $repo->countUnread($user),
-        ]);
+        ]));
     }
 
     #[Route('/settings', name: 'settings')]
@@ -84,11 +88,11 @@ class NotificationController extends AbstractController
             return $this->redirectToRoute('account_notification_settings');
         }
 
-        return $this->render('account/notification_settings.html.twig', [
+        return $this->privateResponse($this->render('account/notification_settings.html.twig', [
             'eventTypes' => self::EVENT_TYPES,
             'channels'   => self::CHANNELS,
             'settings'   => $indexed,
-        ]);
+        ]));
     }
 
     #[Route('/mark-read/{id}', name: 'mark_read', requirements: ['id' => '\d+'], methods: ['POST'])]
@@ -135,5 +139,14 @@ class NotificationController extends AbstractController
         $em->flush();
 
         return $this->redirectToRoute('account_notification_index');
+    }
+
+    private function privateResponse(Response $response): Response
+    {
+        $response->setPrivate();
+        $response->setMaxAge(0);
+        $response->headers->addCacheControlDirective('no-store');
+
+        return $response;
     }
 }

--- a/src/Entity/Notification.php
+++ b/src/Entity/Notification.php
@@ -9,6 +9,7 @@ use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity(repositoryClass: NotificationRepository::class)]
+#[ORM\UniqueConstraint(name: 'uniq_notification_recipient_dedupe', columns: ['recipient_id', 'dedupe_key'])]
 class Notification
 {
     // Типы событий
@@ -22,6 +23,10 @@ class Notification
     public const TYPE_SYSTEM = 'system';
     public const TYPE_PURCHASE_REQUEST_NEW = 'purchase_request_new';
     public const TYPE_PURCHASE_REQUEST_DECIDED = 'purchase_request_decided';
+    public const TYPE_PURCHASE_FITTING = 'purchase_fitting';
+    public const TYPE_PURCHASE_BOUGHT = 'purchase_bought';
+    public const TYPE_PURCHASE_REFUSED = 'purchase_refused';
+    public const TYPE_PURCHASE_RETURNED = 'purchase_returned';
 
     // Каналы доставки
     public const CHANNEL_INAPP = 'inapp';
@@ -49,6 +54,9 @@ class Notification
     // Дополнительные данные (id заказа, ссылка, etc.)
     #[ORM\Column(type: Types::JSON, nullable: true)]
     private ?array $data = null;
+
+    #[ORM\Column(length: 100, nullable: true)]
+    private ?string $dedupeKey = null;
 
     #[ORM\Column(options: ['default' => false])]
     private bool $isRead = false;
@@ -113,6 +121,14 @@ class Notification
     public function setData(?array $data): static
     {
         $this->data = $data;
+        return $this;
+    }
+
+    public function getDedupeKey(): ?string { return $this->dedupeKey; }
+
+    public function setDedupeKey(?string $dedupeKey): static
+    {
+        $this->dedupeKey = $dedupeKey;
         return $this;
     }
 

--- a/src/Notification/NotificationDispatcher.php
+++ b/src/Notification/NotificationDispatcher.php
@@ -74,10 +74,34 @@ readonly class NotificationDispatcher
         $this->createInApp($recipient, $type, $title, $body, $data);
     }
 
+    /** @param array<string, mixed>|null $data */
+    public function dispatchInAppOnce(
+        User $recipient,
+        string $type,
+        string $dedupeKey,
+        string $title,
+        ?string $body = null,
+        ?array $data = null,
+    ): void {
+        $settings = $this->settingsRepo->findOneBy(['user' => $recipient, 'eventType' => $type]);
+        if ($settings !== null && !$settings->isChannelInapp()) {
+            return;
+        }
+        if ($this->em->getRepository(Notification::class)->findOneBy([
+            'recipient' => $recipient,
+            'dedupeKey' => $dedupeKey,
+        ]) !== null) {
+            return;
+        }
+
+        $notification = $this->createInApp($recipient, $type, $title, $body, $data);
+        $notification->setDedupeKey($dedupeKey);
+    }
+
     /**
      * @param array<string, mixed>|null $data
      */
-    private function createInApp(User $recipient, string $type, string $title, ?string $body = null, ?array $data = null): void
+    private function createInApp(User $recipient, string $type, string $title, ?string $body = null, ?array $data = null): Notification
     {
         $notification = new Notification();
         $notification->setRecipient($recipient);
@@ -88,5 +112,7 @@ readonly class NotificationDispatcher
         $notification->setChannel(Notification::CHANNEL_INAPP);
 
         $this->em->persist($notification);
+
+        return $notification;
     }
 }

--- a/src/Service/PurchaseRequestService.php
+++ b/src/Service/PurchaseRequestService.php
@@ -199,9 +199,14 @@ class PurchaseRequestService
         ?string $comment,
     ): void {
         $this->assertCanRecordFitting($actor, $request, $item);
+        $notificationType = match ($outcome) {
+            FittingFeedback::OUTCOME_BOUGHT => Notification::TYPE_PURCHASE_BOUGHT,
+            FittingFeedback::OUTCOME_REFUSED, FittingFeedback::OUTCOME_DIFFERENT_SIZE => Notification::TYPE_PURCHASE_REFUSED,
+            default => Notification::TYPE_PURCHASE_FITTING,
+        };
         $this->mutateItem($actor, $request, $item, PurchaseRequestEvent::TYPE_FITTING, static function (PurchaseRequestItem $locked) use ($actor, $outcome, $triedSize, $sizing, $fitIssues, $comment): void {
             $locked->recordFitting(new FittingFeedback($actor, $outcome, $triedSize, $sizing, $fitIssues, $comment));
-        });
+        }, $notificationType);
     }
 
     public function markReturned(User $actor, PurchaseRequest $request, PurchaseRequestItem $item): void
@@ -223,6 +228,7 @@ class PurchaseRequestService
 
             $subject = $request->getSubject();
             \assert($subject instanceof User);
+            $this->notifyParents($actor, $subject, $request, $item, Notification::TYPE_PURCHASE_RETURNED);
             if ($actor->getId() !== $subject->getId()) {
                 $this->notifications->dispatchInApp(
                     $subject,
@@ -303,14 +309,17 @@ class PurchaseRequestService
     }
 
     /** @param callable(PurchaseRequestItem): void $mutation */
-    private function mutateItem(User $actor, PurchaseRequest $request, PurchaseRequestItem $item, string $eventType, callable $mutation): void
+    private function mutateItem(User $actor, PurchaseRequest $request, PurchaseRequestItem $item, string $eventType, callable $mutation, ?string $parentNotificationType = null): void
     {
-        $this->transactional(function () use ($actor, $request, $item, $eventType, $mutation): void {
+        $this->transactional(function () use ($actor, $request, $item, $eventType, $mutation, $parentNotificationType): void {
             $this->em->refresh($item, LockMode::PESSIMISTIC_WRITE);
             $mutation($item);
             $request->addEvent((new PurchaseRequestEvent($actor, $eventType))->setItem($item));
             $subject = $request->getSubject();
             \assert($subject instanceof User);
+            if ($parentNotificationType !== null) {
+                $this->notifyParents($actor, $subject, $request, $item, $parentNotificationType);
+            }
             if ($actor->getId() !== $subject->getId()) {
                 $this->notifications->dispatchInApp(
                     $subject,
@@ -321,5 +330,28 @@ class PurchaseRequestService
                 );
             }
         });
+    }
+
+    private function notifyParents(User $actor, User $subject, PurchaseRequest $request, PurchaseRequestItem $item, string $type): void
+    {
+        $titles = [
+            Notification::TYPE_PURCHASE_FITTING => '%s оставил(а) результат примерки',
+            Notification::TYPE_PURCHASE_BOUGHT => '%s выкупил(а) вещь',
+            Notification::TYPE_PURCHASE_REFUSED => '%s отказался(-ась) от вещи',
+            Notification::TYPE_PURCHASE_RETURNED => 'Вещь для %s возвращена',
+        ];
+        foreach ($this->families->membersFor($subject) as $parent) {
+            if (!$parent->isFamilyParent() || $parent->getId() === $actor->getId()) {
+                continue;
+            }
+            $this->notifications->dispatchInAppOnce(
+                $parent,
+                $type,
+                sprintf('purchase-item:%d:%s:recipient:%d', $item->getId(), $type, $parent->getId()),
+                sprintf($titles[$type], $subject->getFirstName() ?: 'Ребёнок'),
+                null,
+                ['url' => '/account/purchases/'.$request->getId()],
+            );
+        }
     }
 }

--- a/tests/Controller/NotificationSecurityTest.php
+++ b/tests/Controller/NotificationSecurityTest.php
@@ -36,11 +36,39 @@ class NotificationSecurityTest extends AuthenticatedWebTestCase
         $this->assertFalse($notification->isRead());
 
         $crawler = $client->request('GET', '/account/notifications');
+        $cacheControl = (string) $client->getResponse()->headers->get('Cache-Control');
+        $this->assertStringContainsString('private', $cacheControl);
+        $this->assertStringContainsString('no-store', $cacheControl);
         $form = $crawler->filter(sprintf('form[action="/account/notifications/mark-read/%d"]', $notification->getId()))->form();
         $client->submit($form);
         $em->clear();
         $notification = $em->getRepository(Notification::class)->find($notification->getId());
         $this->assertTrue($notification->isRead());
+    }
+
+    public function testUserCannotMarkAnotherUsersNotificationAsRead(): void
+    {
+        $client = static::createClient();
+        $owner = UserFactory::withEmail(static::getContainer(), 'notification-owner@test.local');
+        $actor = UserFactory::withEmail(static::getContainer(), 'notification-idor@test.local');
+        $notification = (new Notification())
+            ->setRecipient($actor)
+            ->setType(Notification::TYPE_PURCHASE_BOUGHT)
+            ->setTitle('Выкуплена вещь');
+        $em = static::getContainer()->get('doctrine.orm.entity_manager');
+        $em->persist($notification);
+        $em->flush();
+        $client->loginUser($actor);
+        $crawler = $client->request('GET', '/account/notifications');
+        $form = $crawler->filter(sprintf('form[action="/account/notifications/mark-read/%d"]', $notification->getId()))->form();
+        $notification->setRecipient($owner);
+        $em->flush();
+
+        $client->submit($form);
+
+        $this->assertResponseRedirects('/account/notifications');
+        $em->clear();
+        $this->assertFalse($em->getRepository(Notification::class)->find($notification->getId())->isRead());
     }
 
     public function testUnsafeInternalNotificationUrlIsNotRendered(): void

--- a/tests/Controller/PurchaseRequestControllerTest.php
+++ b/tests/Controller/PurchaseRequestControllerTest.php
@@ -475,6 +475,118 @@ class PurchaseRequestControllerTest extends AuthenticatedWebTestCase
         $this->assertCount(2, $secondParentNotifications);
     }
 
+    public function testChildFittingOutcomeNotifiesParentsOnceWithDistinctType(): void
+    {
+        $firstParent = UserFactory::withEmail(static::getContainer(), $this->email('fitting-first-parent'));
+        $secondParent = UserFactory::withEmail(static::getContainer(), $this->email('fitting-second-parent'));
+        $invite = $this->families()->createInvite($firstParent, User::FAMILY_ROLE_PARENT);
+        $this->families()->acceptInvite($secondParent, $invite);
+        $child = $this->families()->createChild($firstParent, 'Мила');
+        $sibling = $this->families()->createChild($firstParent, 'Лиза');
+        $request = $this->purchaseRequests()->create($child, $child, 'https://shop.example.test/item/fitting-notice', null);
+        /** @var PurchaseRequestItem $item */
+        $item = $request->getItems()->first();
+        $this->purchaseRequests()->decideItem($firstParent, $request, $item, PurchaseRequest::STATUS_APPROVED);
+        $this->purchaseRequests()->markOrdered($firstParent, $request, $item, null);
+        $this->purchaseRequests()->markDelivered($firstParent, $request, $item);
+
+        $this->purchaseRequests()->recordFitting($child, $request, $item, FittingFeedback::OUTCOME_PENDING, '152', null, [], null);
+
+        $notifications = $this->em()->getRepository(Notification::class)->findBy([
+            'type' => Notification::TYPE_PURCHASE_FITTING,
+        ]);
+        $this->assertCount(2, $notifications);
+        $this->assertEqualsCanonicalizing(
+            [$firstParent->getId(), $secondParent->getId()],
+            array_map(static fn (Notification $notification): ?int => $notification->getRecipient()?->getId(), $notifications),
+        );
+        $this->assertNotContains($child->getId(), array_map(static fn (Notification $notification): ?int => $notification->getRecipient()?->getId(), $notifications));
+        $this->assertNotContains($sibling->getId(), array_map(static fn (Notification $notification): ?int => $notification->getRecipient()?->getId(), $notifications));
+
+        $firstNotification = array_values(array_filter(
+            $notifications,
+            static fn (Notification $notification): bool => $notification->getRecipient()?->getId() === $firstParent->getId(),
+        ))[0];
+        static::getContainer()->get(\App\Notification\NotificationDispatcher::class)->dispatchInAppOnce(
+            $firstParent,
+            Notification::TYPE_PURCHASE_FITTING,
+            (string) $firstNotification->getDedupeKey(),
+            'Повторная доставка',
+        );
+        $this->em()->flush();
+        $this->assertCount(1, $this->em()->getRepository(Notification::class)->findBy([
+            'recipient' => $firstParent,
+            'type' => Notification::TYPE_PURCHASE_FITTING,
+        ]));
+    }
+
+    public function testBoughtNotificationHonoursEachParentsInAppSetting(): void
+    {
+        $firstParent = UserFactory::withEmail(static::getContainer(), $this->email('bought-first-parent'));
+        $secondParent = UserFactory::withEmail(static::getContainer(), $this->email('bought-second-parent'));
+        $invite = $this->families()->createInvite($firstParent, User::FAMILY_ROLE_PARENT);
+        $this->families()->acceptInvite($secondParent, $invite);
+        $child = $this->families()->createChild($firstParent, 'Аня');
+        $settings = (new \App\Entity\NotificationSettings())
+            ->setUser($secondParent)
+            ->setEventType(Notification::TYPE_PURCHASE_BOUGHT)
+            ->setChannelInapp(false);
+        $this->em()->persist($settings);
+        $this->em()->flush();
+        $request = $this->purchaseRequests()->create($child, $child, 'https://shop.example.test/item/bought-notice', null);
+        /** @var PurchaseRequestItem $item */
+        $item = $request->getItems()->first();
+        $this->purchaseRequests()->decideItem($firstParent, $request, $item, PurchaseRequest::STATUS_APPROVED);
+        $this->purchaseRequests()->markOrdered($firstParent, $request, $item, null);
+        $this->purchaseRequests()->markDelivered($firstParent, $request, $item);
+
+        $this->purchaseRequests()->recordFitting($child, $request, $item, FittingFeedback::OUTCOME_BOUGHT, null, null, [], null);
+
+        $this->assertCount(1, $this->em()->getRepository(Notification::class)->findBy([
+            'recipient' => $firstParent,
+            'type' => Notification::TYPE_PURCHASE_BOUGHT,
+        ]));
+        $this->assertCount(0, $this->em()->getRepository(Notification::class)->findBy([
+            'recipient' => $secondParent,
+            'type' => Notification::TYPE_PURCHASE_BOUGHT,
+        ]));
+    }
+
+    public function testRefusedAndReturnedUseDistinctParentNotificationTypes(): void
+    {
+        $firstParent = UserFactory::withEmail(static::getContainer(), $this->email('status-first-parent'));
+        $secondParent = UserFactory::withEmail(static::getContainer(), $this->email('status-second-parent'));
+        $invite = $this->families()->createInvite($firstParent, User::FAMILY_ROLE_PARENT);
+        $this->families()->acceptInvite($secondParent, $invite);
+        $child = $this->families()->createChild($firstParent, 'Саша');
+
+        $refusedRequest = $this->deliveredRequest($firstParent, $child, 'refused-notice');
+        /** @var PurchaseRequestItem $refusedItem */
+        $refusedItem = $refusedRequest->getItems()->first();
+        $this->purchaseRequests()->recordFitting($child, $refusedRequest, $refusedItem, FittingFeedback::OUTCOME_REFUSED, null, null, [], 'Не подошло');
+
+        $returnedRequest = $this->deliveredRequest($firstParent, $child, 'returned-notice');
+        /** @var PurchaseRequestItem $returnedItem */
+        $returnedItem = $returnedRequest->getItems()->first();
+        $this->purchaseRequests()->recordFitting($child, $returnedRequest, $returnedItem, FittingFeedback::OUTCOME_BOUGHT, null, null, [], null);
+        $this->purchaseRequests()->markReturned($firstParent, $returnedRequest, $returnedItem);
+
+        foreach ([$firstParent, $secondParent] as $parent) {
+            $this->assertCount(1, $this->em()->getRepository(Notification::class)->findBy([
+                'recipient' => $parent,
+                'type' => Notification::TYPE_PURCHASE_REFUSED,
+            ]));
+        }
+        $this->assertCount(0, $this->em()->getRepository(Notification::class)->findBy([
+            'recipient' => $firstParent,
+            'type' => Notification::TYPE_PURCHASE_RETURNED,
+        ]));
+        $this->assertCount(1, $this->em()->getRepository(Notification::class)->findBy([
+            'recipient' => $secondParent,
+            'type' => Notification::TYPE_PURCHASE_RETURNED,
+        ]));
+    }
+
     public function testMonthlyBudgetRequiresExplicitOverspendApproval(): void
     {
         $parent = UserFactory::withEmail(static::getContainer(), $this->email('budget-parent'));
@@ -665,6 +777,18 @@ class PurchaseRequestControllerTest extends AuthenticatedWebTestCase
     private function purchaseRequests(): PurchaseRequestService
     {
         return static::getContainer()->get(PurchaseRequestService::class);
+    }
+
+    private function deliveredRequest(User $parent, User $child, string $slug): PurchaseRequest
+    {
+        $request = $this->purchaseRequests()->create($child, $child, 'https://shop.example.test/item/'.$slug, null);
+        /** @var PurchaseRequestItem $item */
+        $item = $request->getItems()->first();
+        $this->purchaseRequests()->decideItem($parent, $request, $item, PurchaseRequest::STATUS_APPROVED);
+        $this->purchaseRequests()->markOrdered($parent, $request, $item, null);
+        $this->purchaseRequests()->markDelivered($parent, $request, $item);
+
+        return $request;
     }
 
     private function em(): EntityManagerInterface


### PR DESCRIPTION
## Что изменено
- добавлены отдельные in-app типы для результата примерки, выкупа, отказа и возврата детской покупки
- уведомляются родители семьи, кроме инициатора; sibling и посторонние не получают события
- настройки in-app учитываются отдельно для каждого типа
- добавлен стабильный dedupe-key с уникальным индексом
- страницы уведомлений отдаются с private/no-store
- добавлены проверки recipients, settings, dedupe и IDOR mark-read
- после rebase на main сохранена reconciliation-логика возврата: идемпотентность, блокировки и ITEM_RETURNED для связанной вещи

## Проверки после rebase на main
- vendor/bin/phpunit tests/Controller/PurchaseRequestControllerTest.php tests/Controller/NotificationSecurityTest.php tests/Service/NotificationDispatcherTest.php — 35 tests, 130 assertions
- container lint (test) — OK
- Doctrine schema validate mapping (test) — OK

## Известное ограничение окружения
Полная suite в свежем worktree останавливалась на существующем RagBrandPanelTest: не установлены importmap vendor-assets EasyAdmin (@hotwired/stimulus). Изменённый блок и reconciliation focused-тесты проходят.