### PR TITLE
feat(api): add rotating native device auth

### DIFF
--- a/config/packages/rate_limiter.yaml
+++ b/config/packages/rate_limiter.yaml
@@ -43,6 +43,16 @@ framework:
             limit: 10
             interval: '1 hour'
 
+        native_auth_login:
+            policy: sliding_window
+            limit: 5
+            interval: '15 minutes'
+
+        native_auth_refresh:
+            policy: sliding_window
+            limit: 30
+            interval: '1 minute'
+
 # В тестах дневное окно wardrobe_ai живёт в var/cache/test МЕЖДУ прогонами
 # (тест-БД одноразовая → user id повторяются) — после ~30 прогонов сьют
 # начинает флейкать 429. Лимитер в тестах отключаем.
@@ -52,4 +62,8 @@ when@test:
             wardrobe_ai:
                 policy: no_limit
             wardrobe_ingest:
+                policy: no_limit
+            native_auth_login:
+                policy: no_limit
+            native_auth_refresh:
                 policy: no_limit

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -51,6 +51,8 @@ security:
         main:
             lazy: true
             provider: app_user_provider
+            custom_authenticators:
+                - App\Security\NativeDeviceAuthenticator
             form_login:
                 login_path: app_login
                 check_path: app_login

--- a/docs/native_device_auth.md
+++ b/docs/native_device_auth.md
@@ -1,0 +1,62 @@
+# Native device auth для wardrobe API
+
+Нативный клиент использует opaque credentials только для `/api/v1/wardrobe-app/*`.
+PWA продолжает работать с существующей Symfony session cookie без изменений.
+
+## Получение токенов
+
+```http
+POST /api/v1/wardrobe-app/auth/login
+Content-Type: application/json
+
+{"email":"user@example.com","password":"...","deviceId":"ios-installation-uuid"}
+```
+
+Ответ содержит короткоживущий access token (15 минут) и refresh token (30 дней). Клиент обязан
+хранить их в iOS Keychain, не в `UserDefaults`, логах или аналитике. `deviceId` — случайный стабильный
+идентификатор установки длиной 8–128 символов, не IDFA и не аппаратный fingerprint.
+
+Access передаётся стандартно:
+
+```http
+Authorization: Bearer <accessToken>
+```
+
+В БД сохраняются только SHA-256 hashes access/refresh/device ID. Raw tokens возвращаются один раз,
+все ответы auth API имеют `Cache-Control: no-store, private`. Login ограничен пятью попытками за
+15 минут на пару IP+email; ответ для неизвестного email и неверного пароля одинаковый.
+
+## Rotation и отзыв
+
+```http
+POST /api/v1/wardrobe-app/auth/refresh
+{"refreshToken":"..."}
+
+POST /api/v1/wardrobe-app/auth/revoke
+Authorization: Bearer <accessToken>
+
+POST /api/v1/wardrobe-app/auth/revoke-all
+Authorization: Bearer <accessToken>
+```
+
+Каждый refresh одноразовый и атомарно заменяет access и refresh. Повторное предъявление уже
+использованного refresh считается reuse: вся device session отзывается, включая новый access.
+`revoke` отзывает текущее устройство, `revoke-all` — все устройства пользователя. Оба endpoint
+требуют native Bearer-контекст и не принимают одну лишь browser cookie, поэтому не создают CSRF-path.
+
+Повторный login с тем же `deviceId` отзывает прежнюю сессию установки. Заблокированные пользователи
+не могут получить токены. Family authorization после аутентификации остаётся в `FamilyService`, как
+для PWA: детский токен не открывает гардероб родителя, sibling или постороннего пользователя.
+
+## Production smoke
+
+После миграции выполнить login тестового аккаунта, затем:
+
+1. вызвать `/bootstrap` с access — ожидается 200 и `no-store`;
+2. refresh — новые access и refresh отличаются от старых;
+3. старый access — 401;
+4. повторить старый refresh — 401, новый access после reuse тоже 401;
+5. убедиться SQL-проверкой, что колонки содержат 64-символьные hashes, а raw tokens нигде не записаны.
+
+Не помещать токены в query string. OIDC/social sign-in и фоновые push credentials не входят в этот
+атомарный контур и должны добавляться отдельным threat-model/PR.

--- a/docs/wardrobe_roadmap.md
+++ b/docs/wardrobe_roadmap.md
@@ -25,6 +25,9 @@
 | 6 | **AI-стилист**: подбор до трёх образов из активных вещей, реакции и персональная память на подтверждённых носках/comfort/repeat; embeddings и общий опыт только по consent | ✅ персональный MVP 2026-08-24; [дизайн обучения](wardrobe_ai_learning.md) |
 | 7 | **Клиенты**: mobile-first PWA поверх versioned API; после проверки метрик — нативный iOS-клиент того же API; Telegram только дополнительный канал | 📋 [план](family_purchase_learning.md) |
 
+Native-клиент аутентифицируется отдельными opaque device credentials с rotation/reuse detection;
+PWA сохраняет session cookie. Контракт и правила хранения: [native device auth](native_device_auth.md).
+
 ## Extension points, заложенные в фундамент итерации 3
 
 - `Family` — первоклассная сущность (к ней цепляются бюджеты и вишлисты итерации 4).

--- a/migrations/Version20260824_native_device_auth.php
+++ b/migrations/Version20260824_native_device_auth.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260824_native_device_auth extends AbstractMigration
+{
+    public function getDescription(): string { return 'Opaque rotating native device credentials for wardrobe API'; }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE TABLE native_device_session (id INT AUTO_INCREMENT NOT NULL, user_id INT NOT NULL, device_hash VARCHAR(64) NOT NULL, access_hash VARCHAR(64) NOT NULL, access_expires_at DATETIME NOT NULL COMMENT \'(DC2Type:datetime_immutable)\', revoked_at DATETIME DEFAULT NULL COMMENT \'(DC2Type:datetime_immutable)\', created_at DATETIME NOT NULL COMMENT \'(DC2Type:datetime_immutable)\', UNIQUE INDEX UNIQ_NATIVE_ACCESS_HASH (access_hash), INDEX idx_native_session_user_device (user_id, device_hash), INDEX IDX_NATIVE_SESSION_USER (user_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE native_refresh_token (id INT AUTO_INCREMENT NOT NULL, session_id INT NOT NULL, token_hash VARCHAR(64) NOT NULL, expires_at DATETIME NOT NULL COMMENT \'(DC2Type:datetime_immutable)\', used_at DATETIME DEFAULT NULL COMMENT \'(DC2Type:datetime_immutable)\', created_at DATETIME NOT NULL COMMENT \'(DC2Type:datetime_immutable)\', UNIQUE INDEX UNIQ_NATIVE_REFRESH_HASH (token_hash), INDEX IDX_NATIVE_REFRESH_SESSION (session_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('ALTER TABLE native_device_session ADD CONSTRAINT FK_NATIVE_SESSION_USER FOREIGN KEY (user_id) REFERENCES client (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE native_refresh_token ADD CONSTRAINT FK_NATIVE_REFRESH_SESSION FOREIGN KEY (session_id) REFERENCES native_device_session (id) ON DELETE CASCADE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP TABLE native_refresh_token');
+        $this->addSql('DROP TABLE native_device_session');
+    }
+}

--- a/src/Controller/Api/NativeDeviceAuthController.php
+++ b/src/Controller/Api/NativeDeviceAuthController.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller\Api;
+
+use App\Entity\User;
+use App\Service\NativeDeviceAuth;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\RateLimiter\RateLimiterFactory;
+use Symfony\Component\Routing\Attribute\Route;
+
+#[Route('/api/v1/wardrobe-app/auth', name: 'api_wardrobe_native_auth_')]
+final class NativeDeviceAuthController extends AbstractController
+{
+    public function __construct(private readonly NativeDeviceAuth $auth) {}
+
+    #[Route('/login', name: 'login', methods: ['POST'])]
+    public function login(Request $request, RateLimiterFactory $nativeAuthLoginLimiter): JsonResponse
+    {
+        $data = $this->body($request);
+        $email = is_string($data['email'] ?? null) ? trim($data['email']) : '';
+        $key = hash('sha256', ($request->getClientIp() ?? 'unknown').'|'.mb_strtolower($email));
+        if (!$nativeAuthLoginLimiter->create($key)->consume()->isAccepted()) {
+            return $this->jsonPrivate(['error' => 'rate_limited'], Response::HTTP_TOO_MANY_REQUESTS);
+        }
+        $password = is_string($data['password'] ?? null) ? $data['password'] : '';
+        $deviceId = is_string($data['deviceId'] ?? null) ? trim($data['deviceId']) : '';
+        if ($email === '' || $password === '' || strlen($password) > 4096 || strlen($deviceId) < 8 || strlen($deviceId) > 128) {
+            return $this->jsonPrivate(['error' => 'invalid_credentials'], Response::HTTP_UNAUTHORIZED);
+        }
+
+        try {
+            return $this->jsonPrivate($this->auth->login($email, $password, $deviceId));
+        } catch (\DomainException) {
+            return $this->jsonPrivate(['error' => 'invalid_credentials'], Response::HTTP_UNAUTHORIZED);
+        }
+    }
+
+    #[Route('/refresh', name: 'refresh', methods: ['POST'])]
+    public function refresh(Request $request, RateLimiterFactory $nativeAuthRefreshLimiter): JsonResponse
+    {
+        if (!$nativeAuthRefreshLimiter->create($request->getClientIp() ?? 'unknown')->consume()->isAccepted()) {
+            return $this->jsonPrivate(['error' => 'rate_limited'], Response::HTTP_TOO_MANY_REQUESTS);
+        }
+        $data = $this->body($request);
+        $refreshToken = is_string($data['refreshToken'] ?? null) ? $data['refreshToken'] : '';
+        if ($refreshToken === '' || strlen($refreshToken) > 256) {
+            return $this->jsonPrivate(['error' => 'invalid_refresh_token'], Response::HTTP_UNAUTHORIZED);
+        }
+
+        try {
+            return $this->jsonPrivate($this->auth->refresh($refreshToken));
+        } catch (\DomainException) {
+            return $this->jsonPrivate(['error' => 'invalid_refresh_token'], Response::HTTP_UNAUTHORIZED);
+        }
+    }
+
+    #[Route('/revoke', name: 'revoke', methods: ['POST'])]
+    public function revoke(Request $request): JsonResponse
+    {
+        $user = $this->getUser();
+        $sessionId = $request->attributes->getInt('_native_device_session_id');
+        if (!$user instanceof User || $sessionId < 1) {
+            return $this->jsonPrivate(['error' => 'native_authentication_required'], Response::HTTP_UNAUTHORIZED);
+        }
+        $this->auth->revokeSession($sessionId, $user);
+
+        return $this->jsonPrivate(['ok' => true]);
+    }
+
+    #[Route('/revoke-all', name: 'revoke_all', methods: ['POST'])]
+    public function revokeAll(Request $request): JsonResponse
+    {
+        $user = $this->getUser();
+        if (!$user instanceof User || $request->attributes->getInt('_native_device_session_id') < 1) {
+            return $this->jsonPrivate(['error' => 'native_authentication_required'], Response::HTTP_UNAUTHORIZED);
+        }
+        $this->auth->revokeAll($user);
+
+        return $this->jsonPrivate(['ok' => true]);
+    }
+
+    /** @return array<string, mixed> */
+    private function body(Request $request): array
+    {
+        try {
+            return $request->toArray();
+        } catch (\Throwable) {
+            return [];
+        }
+    }
+
+    private function jsonPrivate(array $data, int $status = Response::HTTP_OK): JsonResponse
+    {
+        return $this->json($data, $status, ['Cache-Control' => 'no-store, private']);
+    }
+}

--- a/src/Entity/NativeDeviceSession.php
+++ b/src/Entity/NativeDeviceSession.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity;
+
+use App\Repository\NativeDeviceSessionRepository;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity(repositoryClass: NativeDeviceSessionRepository::class)]
+#[ORM\Table(name: 'native_device_session')]
+#[ORM\Index(name: 'idx_native_session_user_device', columns: ['user_id', 'device_hash'])]
+class NativeDeviceSession
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    private ?int $id = null;
+
+    #[ORM\ManyToOne]
+    #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
+    private User $user;
+
+    #[ORM\Column(name: 'device_hash', length: 64)]
+    private string $deviceHash;
+
+    #[ORM\Column(name: 'access_hash', length: 64, unique: true)]
+    private string $accessHash;
+
+    #[ORM\Column]
+    private \DateTimeImmutable $accessExpiresAt;
+
+    #[ORM\Column(nullable: true)]
+    private ?\DateTimeImmutable $revokedAt = null;
+
+    #[ORM\Column]
+    private \DateTimeImmutable $createdAt;
+
+    /** @var Collection<int, NativeRefreshToken> */
+    #[ORM\OneToMany(targetEntity: NativeRefreshToken::class, mappedBy: 'session', cascade: ['persist'], orphanRemoval: true)]
+    private Collection $refreshTokens;
+
+    public function __construct(User $user, string $deviceHash, string $accessHash, \DateTimeImmutable $accessExpiresAt)
+    {
+        $this->user = $user;
+        $this->deviceHash = $deviceHash;
+        $this->accessHash = $accessHash;
+        $this->accessExpiresAt = $accessExpiresAt;
+        $this->createdAt = new \DateTimeImmutable();
+        $this->refreshTokens = new ArrayCollection();
+    }
+
+    public function getId(): ?int { return $this->id; }
+    public function getUser(): User { return $this->user; }
+    public function getDeviceHash(): string { return $this->deviceHash; }
+    public function getAccessHash(): string { return $this->accessHash; }
+    public function getAccessExpiresAt(): \DateTimeImmutable { return $this->accessExpiresAt; }
+    public function getRevokedAt(): ?\DateTimeImmutable { return $this->revokedAt; }
+    public function isRevoked(): bool { return $this->revokedAt !== null; }
+
+    public function rotateAccess(string $accessHash, \DateTimeImmutable $expiresAt): void
+    {
+        $this->accessHash = $accessHash;
+        $this->accessExpiresAt = $expiresAt;
+    }
+
+    public function revoke(): void { $this->revokedAt ??= new \DateTimeImmutable(); }
+
+    public function addRefreshToken(NativeRefreshToken $token): void
+    {
+        $this->refreshTokens->add($token);
+    }
+}

--- a/src/Entity/NativeRefreshToken.php
+++ b/src/Entity/NativeRefreshToken.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity;
+
+use App\Repository\NativeRefreshTokenRepository;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity(repositoryClass: NativeRefreshTokenRepository::class)]
+#[ORM\Table(name: 'native_refresh_token')]
+class NativeRefreshToken
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    private ?int $id = null;
+
+    #[ORM\ManyToOne(inversedBy: 'refreshTokens')]
+    #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
+    private NativeDeviceSession $session;
+
+    #[ORM\Column(name: 'token_hash', length: 64, unique: true)]
+    private string $tokenHash;
+
+    #[ORM\Column]
+    private \DateTimeImmutable $expiresAt;
+
+    #[ORM\Column(nullable: true)]
+    private ?\DateTimeImmutable $usedAt = null;
+
+    #[ORM\Column]
+    private \DateTimeImmutable $createdAt;
+
+    public function __construct(NativeDeviceSession $session, string $tokenHash, \DateTimeImmutable $expiresAt)
+    {
+        $this->session = $session;
+        $this->tokenHash = $tokenHash;
+        $this->expiresAt = $expiresAt;
+        $this->createdAt = new \DateTimeImmutable();
+    }
+
+    public function getId(): ?int { return $this->id; }
+    public function getSession(): NativeDeviceSession { return $this->session; }
+    public function getExpiresAt(): \DateTimeImmutable { return $this->expiresAt; }
+    public function isUsed(): bool { return $this->usedAt !== null; }
+    public function markUsed(): void { $this->usedAt ??= new \DateTimeImmutable(); }
+}

--- a/src/Repository/NativeDeviceSessionRepository.php
+++ b/src/Repository/NativeDeviceSessionRepository.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repository;
+
+use App\Entity\NativeDeviceSession;
+use App\Entity\User;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/** @extends ServiceEntityRepository<NativeDeviceSession> */
+final class NativeDeviceSessionRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry) { parent::__construct($registry, NativeDeviceSession::class); }
+
+    public function findValidAccess(string $hash, \DateTimeImmutable $now): ?NativeDeviceSession
+    {
+        return $this->createQueryBuilder('s')->andWhere('s.accessHash = :hash')->andWhere('s.revokedAt IS NULL')
+            ->andWhere('s.accessExpiresAt > :now')->setParameter('hash', $hash)->setParameter('now', $now)
+            ->getQuery()->getOneOrNullResult();
+    }
+
+    /** @return NativeDeviceSession[] */
+    public function findActiveForDevice(User $user, string $deviceHash): array
+    {
+        return $this->findBy(['user' => $user, 'deviceHash' => $deviceHash, 'revokedAt' => null]);
+    }
+
+    /** @return NativeDeviceSession[] */
+    public function findActiveForUser(User $user): array
+    {
+        return $this->findBy(['user' => $user, 'revokedAt' => null]);
+    }
+}

--- a/src/Repository/NativeRefreshTokenRepository.php
+++ b/src/Repository/NativeRefreshTokenRepository.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repository;
+
+use App\Entity\NativeRefreshToken;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\DBAL\LockMode;
+use Doctrine\Persistence\ManagerRegistry;
+
+/** @extends ServiceEntityRepository<NativeRefreshToken> */
+final class NativeRefreshTokenRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry) { parent::__construct($registry, NativeRefreshToken::class); }
+
+    public function findForUpdate(string $hash): ?NativeRefreshToken
+    {
+        return $this->createQueryBuilder('t')->andWhere('t.tokenHash = :hash')->setParameter('hash', $hash)
+            ->getQuery()->setLockMode(LockMode::PESSIMISTIC_WRITE)->getOneOrNullResult();
+    }
+}

--- a/src/Security/NativeDeviceAuthenticator.php
+++ b/src/Security/NativeDeviceAuthenticator.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Security;
+
+use App\Service\NativeDeviceAuth;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Http\Authenticator\AbstractAuthenticator;
+use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
+use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
+use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
+
+final class NativeDeviceAuthenticator extends AbstractAuthenticator
+{
+    public function __construct(private readonly NativeDeviceAuth $auth) {}
+
+    public function supports(Request $request): ?bool
+    {
+        $path = $request->getPathInfo();
+        if (in_array($path, ['/api/v1/wardrobe-app/auth/login', '/api/v1/wardrobe-app/auth/refresh'], true)) {
+            return false;
+        }
+
+        return str_starts_with($path, '/api/v1/wardrobe-app/')
+            && str_starts_with((string) $request->headers->get('Authorization'), 'Bearer ');
+    }
+
+    public function authenticate(Request $request): Passport
+    {
+        $raw = trim(substr((string) $request->headers->get('Authorization'), 7));
+        $session = $raw === '' ? null : $this->auth->authenticateAccess($raw);
+        if ($session === null) {
+            throw new AuthenticationException('Invalid native access token');
+        }
+        $request->attributes->set('_native_device_session_id', $session->getId());
+
+        return new SelfValidatingPassport(new UserBadge(
+            (string) $session->getUser()->getUserIdentifier(),
+            static fn () => $session->getUser(),
+        ));
+    }
+
+    public function onAuthenticationSuccess(Request $request, TokenInterface $token, string $firewallName): ?Response { return null; }
+
+    public function onAuthenticationFailure(Request $request, AuthenticationException $exception): ?Response
+    {
+        return new JsonResponse(['error' => 'invalid_access_token'], Response::HTTP_UNAUTHORIZED, ['Cache-Control' => 'no-store, private']);
+    }
+}

--- a/src/Service/NativeDeviceAuth.php
+++ b/src/Service/NativeDeviceAuth.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+use App\Entity\NativeDeviceSession;
+use App\Entity\NativeRefreshToken;
+use App\Entity\User;
+use App\Repository\NativeDeviceSessionRepository;
+use App\Repository\NativeRefreshTokenRepository;
+use App\Repository\UserRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\DBAL\LockMode;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+final class NativeDeviceAuth
+{
+    private const ACCESS_TTL = 900;
+    private const REFRESH_TTL = 2_592_000;
+
+    public function __construct(
+        private readonly UserRepository $users,
+        private readonly NativeDeviceSessionRepository $sessions,
+        private readonly NativeRefreshTokenRepository $refreshTokens,
+        private readonly UserPasswordHasherInterface $passwordHasher,
+        private readonly EntityManagerInterface $em,
+    ) {}
+
+    /** @return array{accessToken:string,accessExpiresAt:string,refreshToken:string,refreshExpiresAt:string} */
+    public function login(string $email, string $password, string $deviceId): array
+    {
+        $email = mb_strtolower(trim($email));
+        $user = $this->users->findOneBy(['email' => $email]);
+        $passwordValid = $user instanceof User
+            ? $this->passwordHasher->isPasswordValid($user, $password)
+            : $this->passwordHasher->isPasswordValid($this->dummyUser(), $password);
+        if (!$user instanceof User || !$passwordValid || $user->getStatus() !== 'active') {
+            throw new \DomainException('invalid_credentials');
+        }
+
+        return $this->em->wrapInTransaction(function () use ($user, $deviceId): array {
+            $this->em->lock($user, LockMode::PESSIMISTIC_WRITE);
+            $deviceHash = $this->hash($deviceId);
+            foreach ($this->sessions->findActiveForDevice($user, $deviceHash) as $existing) {
+                $existing->revoke();
+            }
+
+            return $this->issue($user, $deviceHash);
+        });
+    }
+
+    /** @return array{accessToken:string,accessExpiresAt:string,refreshToken:string,refreshExpiresAt:string} */
+    public function refresh(string $rawRefreshToken): array
+    {
+        $result = $this->em->wrapInTransaction(function () use ($rawRefreshToken): array {
+            $token = $this->refreshTokens->findForUpdate($this->hash($rawRefreshToken));
+            if ($token === null) {
+                throw new \DomainException('invalid_refresh_token');
+            }
+            $session = $token->getSession();
+            if ($token->isUsed()) {
+                $session->revoke();
+                $this->em->flush();
+                return ['reuseDetected' => true];
+            }
+            $now = new \DateTimeImmutable();
+            if ($session->isRevoked() || $session->getUser()->getStatus() !== 'active' || $token->getExpiresAt() <= $now) {
+                throw new \DomainException('invalid_refresh_token');
+            }
+
+            $token->markUsed();
+            [$access, $accessExpiresAt] = $this->newToken(self::ACCESS_TTL, 32);
+            [$refresh, $refreshExpiresAt] = $this->newToken(self::REFRESH_TTL, 48);
+            $session->rotateAccess($this->hash($access), $accessExpiresAt);
+            $next = new NativeRefreshToken($session, $this->hash($refresh), $refreshExpiresAt);
+            $session->addRefreshToken($next);
+            $this->em->persist($next);
+            $this->em->flush();
+
+            return $this->response($access, $accessExpiresAt, $refresh, $refreshExpiresAt);
+        });
+        if (isset($result['reuseDetected'])) {
+            throw new \DomainException('invalid_refresh_token');
+        }
+
+        return $result;
+    }
+
+    public function authenticateAccess(string $rawAccessToken): ?NativeDeviceSession
+    {
+        $session = $this->sessions->findValidAccess($this->hash($rawAccessToken), new \DateTimeImmutable());
+
+        return $session?->getUser()->getStatus() === 'active' ? $session : null;
+    }
+
+    public function revokeSession(int $sessionId, User $user): void
+    {
+        $session = $this->sessions->find($sessionId);
+        if ($session === null || $session->getUser()->getId() !== $user->getId()) {
+            throw new \DomainException('invalid_device_session');
+        }
+        $session->revoke();
+        $this->em->flush();
+    }
+
+    public function revokeAll(User $user): void
+    {
+        foreach ($this->sessions->findActiveForUser($user) as $session) {
+            $session->revoke();
+        }
+        $this->em->flush();
+    }
+
+    /** @return array{accessToken:string,accessExpiresAt:string,refreshToken:string,refreshExpiresAt:string} */
+    private function issue(User $user, string $deviceHash): array
+    {
+        [$access, $accessExpiresAt] = $this->newToken(self::ACCESS_TTL, 32);
+        [$refresh, $refreshExpiresAt] = $this->newToken(self::REFRESH_TTL, 48);
+        $session = new NativeDeviceSession($user, $deviceHash, $this->hash($access), $accessExpiresAt);
+        $refreshEntity = new NativeRefreshToken($session, $this->hash($refresh), $refreshExpiresAt);
+        $session->addRefreshToken($refreshEntity);
+        $this->em->persist($session);
+        $this->em->persist($refreshEntity);
+        $this->em->flush();
+
+        return $this->response($access, $accessExpiresAt, $refresh, $refreshExpiresAt);
+    }
+
+    /** @return array{0:string,1:\DateTimeImmutable} */
+    private function newToken(int $ttl, int $bytes): array
+    {
+        return [rtrim(strtr(base64_encode(random_bytes($bytes)), '+/', '-_'), '='), new \DateTimeImmutable("+{$ttl} seconds")];
+    }
+
+    /** @return array{accessToken:string,accessExpiresAt:string,refreshToken:string,refreshExpiresAt:string} */
+    private function response(string $access, \DateTimeImmutable $accessExpiresAt, string $refresh, \DateTimeImmutable $refreshExpiresAt): array
+    {
+        return [
+            'accessToken' => $access,
+            'accessExpiresAt' => $accessExpiresAt->format(DATE_ATOM),
+            'refreshToken' => $refresh,
+            'refreshExpiresAt' => $refreshExpiresAt->format(DATE_ATOM),
+        ];
+    }
+
+    private function hash(string $value): string { return hash('sha256', $value); }
+
+    private function dummyUser(): User
+    {
+        return (new User())->setPassword('$2y$13$M8w7f4/4cNT0izPCBMd36eGX5e.Sy7m7r5gJdYKqPCCQyJxUxoG2K');
+    }
+}

--- a/tests/Controller/Api/NativeDeviceAuthControllerTest.php
+++ b/tests/Controller/Api/NativeDeviceAuthControllerTest.php
@@ -1,0 +1,223 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Controller\Api;
+
+use App\Entity\User;
+use App\Service\FamilyService;
+use App\Tests\Controller\AuthenticatedWebTestCase;
+use App\Tests\Controller\UserFactory;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+final class NativeDeviceAuthControllerTest extends AuthenticatedWebTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->skipIfNoDatabase();
+    }
+
+    public function testLoginIssuesOpaqueTokensAndBearerAccessKeepsSessionAuthCompatible(): void
+    {
+        $client = static::createClient();
+        $user = UserFactory::withEmail(static::getContainer(), $this->email('login'));
+
+        $tokens = $this->login($client, $user);
+        self::assertSame(43, strlen($tokens['accessToken']));
+        self::assertSame(64, strlen($tokens['refreshToken']));
+        self::assertStringContainsString('no-store', (string) $client->getResponse()->headers->get('Cache-Control'));
+        self::assertStringContainsString('private', (string) $client->getResponse()->headers->get('Cache-Control'));
+
+        $connection = static::getContainer()->get('doctrine.orm.entity_manager')->getConnection();
+        $row = $connection->fetchAssociative('SELECT access_hash FROM native_device_session WHERE user_id = ?', [$user->getId()]);
+        $refreshHash = $connection->fetchOne('SELECT token_hash FROM native_refresh_token');
+        self::assertSame(hash('sha256', $tokens['accessToken']), $row['access_hash']);
+        self::assertSame(hash('sha256', $tokens['refreshToken']), $refreshHash);
+        self::assertNotSame($tokens['accessToken'], $row['access_hash']);
+
+        $this->bearer($client, $tokens['accessToken'], '/api/v1/wardrobe-app/bootstrap');
+        self::assertResponseIsSuccessful();
+        self::assertSame($user->getId(), $this->json($client)['user']['id']);
+
+        $client->restart();
+        $client->loginUser($user);
+        $client->request('GET', '/api/v1/wardrobe-app/bootstrap');
+        self::assertResponseIsSuccessful();
+    }
+
+    public function testMissingInvalidAndExpiredAccessAreRejected(): void
+    {
+        $client = static::createClient();
+        $user = UserFactory::withEmail(static::getContainer(), $this->email('access'));
+        $tokens = $this->login($client, $user);
+
+        $client->request('GET', '/api/v1/wardrobe-app/bootstrap');
+        self::assertResponseStatusCodeSame(401);
+        $this->bearer($client, 'not-a-token', '/api/v1/wardrobe-app/bootstrap');
+        self::assertResponseStatusCodeSame(401);
+        self::assertSame('invalid_access_token', $this->json($client)['error']);
+
+        static::getContainer()->get('doctrine.orm.entity_manager')->getConnection()->executeStatement(
+            'UPDATE native_device_session SET access_expires_at = ? WHERE access_hash = ?',
+            [(new \DateTimeImmutable('-1 minute'))->format('Y-m-d H:i:s'), hash('sha256', $tokens['accessToken'])],
+        );
+        $this->bearer($client, $tokens['accessToken'], '/api/v1/wardrobe-app/bootstrap');
+        self::assertResponseStatusCodeSame(401);
+    }
+
+    public function testDisablingUserImmediatelyInvalidatesExistingAccess(): void
+    {
+        $client = static::createClient();
+        $user = UserFactory::withEmail(static::getContainer(), $this->email('disabled-access'));
+        $tokens = $this->login($client, $user);
+        static::getContainer()->get('doctrine.orm.entity_manager')->getConnection()
+            ->executeStatement('UPDATE client SET status = ? WHERE id = ?', ['disabled', $user->getId()]);
+
+        $this->bearer($client, $tokens['accessToken'], '/api/v1/wardrobe-app/bootstrap');
+        self::assertResponseStatusCodeSame(401);
+    }
+
+    public function testInvalidCredentialsDoNotRevealWhetherEmailExists(): void
+    {
+        $client = static::createClient();
+        $user = UserFactory::withEmail(static::getContainer(), $this->email('credentials'));
+
+        $client->jsonRequest('POST', '/api/v1/wardrobe-app/auth/login', [
+            'email' => $user->getEmail(), 'password' => 'wrong', 'deviceId' => 'iphone-invalid-1',
+        ]);
+        self::assertResponseStatusCodeSame(401);
+        $existing = $this->json($client);
+        $client->jsonRequest('POST', '/api/v1/wardrobe-app/auth/login', [
+            'email' => 'missing-'.bin2hex(random_bytes(4)).'@test.local', 'password' => 'wrong', 'deviceId' => 'iphone-invalid-2',
+        ]);
+        self::assertResponseStatusCodeSame(401);
+        self::assertSame($existing, $this->json($client));
+
+        static::getContainer()->get('doctrine.orm.entity_manager')->getConnection()
+            ->executeStatement('UPDATE client SET status = ? WHERE id = ?', ['disabled', $user->getId()]);
+        $client->jsonRequest('POST', '/api/v1/wardrobe-app/auth/login', [
+            'email' => $user->getEmail(), 'password' => UserFactory::PASSWORD, 'deviceId' => 'iphone-disabled-1',
+        ]);
+        self::assertResponseStatusCodeSame(401);
+        self::assertSame($existing, $this->json($client));
+    }
+
+    public function testSecondLoginForSameDeviceRevokesPreviousCredentials(): void
+    {
+        $client = static::createClient();
+        $user = UserFactory::withEmail(static::getContainer(), $this->email('same-device'));
+        $first = $this->login($client, $user, 'stable-ios-installation');
+        $second = $this->login($client, $user, 'stable-ios-installation');
+
+        $this->bearer($client, $first['accessToken'], '/api/v1/wardrobe-app/bootstrap');
+        self::assertResponseStatusCodeSame(401);
+        $client->jsonRequest('POST', '/api/v1/wardrobe-app/auth/refresh', ['refreshToken' => $first['refreshToken']]);
+        self::assertResponseStatusCodeSame(401);
+        $this->bearer($client, $second['accessToken'], '/api/v1/wardrobe-app/bootstrap');
+        self::assertResponseIsSuccessful();
+    }
+
+    public function testRefreshRotatesBothTokensAndReplayRevokesDeviceSession(): void
+    {
+        $client = static::createClient();
+        $user = UserFactory::withEmail(static::getContainer(), $this->email('rotation'));
+        $first = $this->login($client, $user);
+
+        $client->jsonRequest('POST', '/api/v1/wardrobe-app/auth/refresh', ['refreshToken' => $first['refreshToken']]);
+        self::assertResponseIsSuccessful();
+        $second = $this->json($client);
+        self::assertNotSame($first['accessToken'], $second['accessToken']);
+        self::assertNotSame($first['refreshToken'], $second['refreshToken']);
+        $this->bearer($client, $first['accessToken'], '/api/v1/wardrobe-app/bootstrap');
+        self::assertResponseStatusCodeSame(401);
+        $this->bearer($client, $second['accessToken'], '/api/v1/wardrobe-app/bootstrap');
+        self::assertResponseIsSuccessful();
+
+        $client->jsonRequest('POST', '/api/v1/wardrobe-app/auth/refresh', ['refreshToken' => $first['refreshToken']]);
+        self::assertResponseStatusCodeSame(401);
+        $this->bearer($client, $second['accessToken'], '/api/v1/wardrobe-app/bootstrap');
+        self::assertResponseStatusCodeSame(401);
+        $client->jsonRequest('POST', '/api/v1/wardrobe-app/auth/refresh', ['refreshToken' => $second['refreshToken']]);
+        self::assertResponseStatusCodeSame(401);
+    }
+
+    public function testExpiredRefreshAndPerDeviceRevokeAreRejected(): void
+    {
+        $client = static::createClient();
+        $user = UserFactory::withEmail(static::getContainer(), $this->email('revoke'));
+        $expired = $this->login($client, $user, 'iphone-expired-refresh');
+        static::getContainer()->get('doctrine.orm.entity_manager')->getConnection()->executeStatement(
+            'UPDATE native_refresh_token SET expires_at = ? WHERE token_hash = ?',
+            [(new \DateTimeImmutable('-1 minute'))->format('Y-m-d H:i:s'), hash('sha256', $expired['refreshToken'])],
+        );
+        $client->jsonRequest('POST', '/api/v1/wardrobe-app/auth/refresh', ['refreshToken' => $expired['refreshToken']]);
+        self::assertResponseStatusCodeSame(401);
+
+        $tokens = $this->login($client, $user, 'iphone-current-device');
+        $this->bearer($client, $tokens['accessToken'], '/api/v1/wardrobe-app/auth/revoke', 'POST');
+        self::assertResponseIsSuccessful();
+        $this->bearer($client, $tokens['accessToken'], '/api/v1/wardrobe-app/bootstrap');
+        self::assertResponseStatusCodeSame(401);
+    }
+
+    public function testRevokeAllInvalidatesEveryDevice(): void
+    {
+        $client = static::createClient();
+        $user = UserFactory::withEmail(static::getContainer(), $this->email('revoke-all'));
+        $first = $this->login($client, $user, 'iphone-first-device');
+        $second = $this->login($client, $user, 'ipad-second-device');
+
+        $this->bearer($client, $second['accessToken'], '/api/v1/wardrobe-app/auth/revoke-all', 'POST');
+        self::assertResponseIsSuccessful();
+        $this->bearer($client, $first['accessToken'], '/api/v1/wardrobe-app/bootstrap');
+        self::assertResponseStatusCodeSame(401);
+        $this->bearer($client, $second['accessToken'], '/api/v1/wardrobe-app/bootstrap');
+        self::assertResponseStatusCodeSame(401);
+    }
+
+    public function testNativeChildTokenCannotReadParentSiblingOrForeignWardrobe(): void
+    {
+        $client = static::createClient();
+        $parent = UserFactory::withEmail(static::getContainer(), $this->email('family-parent'));
+        $families = static::getContainer()->get(FamilyService::class);
+        $child = $families->createChild($parent, 'Лиза');
+        $sibling = $families->createChild($parent, 'Маша');
+        $foreign = UserFactory::withEmail(static::getContainer(), $this->email('foreign'));
+        $password = 'Native-child-password-2026';
+        $child->setPassword(static::getContainer()->get(UserPasswordHasherInterface::class)->hashPassword($child, $password));
+        static::getContainer()->get('doctrine.orm.entity_manager')->flush();
+        $tokens = $this->login($client, $child, 'iphone-child-device', $password);
+
+        foreach ([$parent, $sibling, $foreign] as $forbidden) {
+            $this->bearer($client, $tokens['accessToken'], '/api/v1/wardrobe-app/items?member='.$forbidden->getId());
+            self::assertResponseStatusCodeSame(403);
+            self::assertSame('member_forbidden', $this->json($client)['error']);
+        }
+    }
+
+    /** @return array<string, string> */
+    private function login(KernelBrowser $client, User $user, string $deviceId = 'iphone-test-device', string $password = UserFactory::PASSWORD): array
+    {
+        $client->jsonRequest('POST', '/api/v1/wardrobe-app/auth/login', [
+            'email' => $user->getEmail(), 'password' => $password, 'deviceId' => $deviceId,
+        ]);
+        self::assertResponseIsSuccessful();
+
+        return $this->json($client);
+    }
+
+    private function bearer(KernelBrowser $client, string $token, string $path, string $method = 'GET'): void
+    {
+        $client->request($method, $path, server: ['HTTP_AUTHORIZATION' => 'Bearer '.$token]);
+    }
+
+    /** @return array<string, mixed> */
+    private function json(KernelBrowser $client): array
+    {
+        return json_decode((string) $client->getResponse()->getContent(), true, flags: JSON_THROW_ON_ERROR);
+    }
+
+    private function email(string $prefix): string { return $prefix.'-'.bin2hex(random_bytes(5)).'@test.local'; }
+}


### PR DESCRIPTION
## Summary
- add opaque 15-minute access and rotating 30-day refresh credentials for `/api/v1/wardrobe-app`
- store only SHA-256 token/device hashes and revoke a device session on refresh-token replay
- add per-device revoke, revoke-all, same-device replacement and credential/refresh rate limits
- keep existing PWA Symfony session authentication unchanged
- preserve FamilyService authorization for native callers

## Security properties
- no JWT or new dependency
- password verification uses the configured Symfony password hasher; unknown and invalid users receive the same response with a dummy hash check
- login limiter key is SHA-256(IP + normalized email), so identifiers are not stored as limiter keys in plaintext
- refresh rotation is pessimistically locked; device login is serialized on the user row
- raw tokens are returned once, never persisted, and auth responses are private/no-store
- revoke endpoints require native Bearer context, avoiding cookie-CSRF

## Tests
- `APP_ENV=test php -d memory_limit=512M vendor/bin/phpunit tests/Controller/AuthControllerTest.php tests/Controller/PasswordResetFlowTest.php tests/Controller/Api/NativeDeviceAuthControllerTest.php tests/Controller/Api/WardrobeAppControllerTest.php tests/Controller/AccessControlTest.php --order-by=default`
  - 58 tests, 190 assertions, 5 existing skips, 4 vendor deprecations
- `APP_ENV=test php -d memory_limit=512M bin/console lint:container`
- `APP_ENV=test php -d memory_limit=512M bin/console doctrine:schema:validate --skip-sync`

## Scope
OIDC/social login and push credentials are explicitly deferred. PWA cookie auth remains supported.