### PR TITLE
feat: deliver external notifications via transactional outbox

### DIFF
--- a/_docs/notification-outbox.md
+++ b/_docs/notification-outbox.md
@@ -1,0 +1,7 @@
+# External notification outbox
+
+`NotificationDispatcher::dispatch()` persists in-app notifications and enabled email/Telegram deliveries in the same domain transaction. It performs no network I/O. Email HTML and Telegram HTML text are snapshotted at enqueue time; the latter is escaped before persistence.
+
+`app:notification:deliver-outbox` claims due rows and sends them after commit. Failed deliveries are isolated and retried with exponential backoff up to five attempts. Preferences are checked both when queued and immediately before delivery, so an opt-out made while a message waits is respected. The production scheduler runs the command every minute. Use `--dry-run` to count pending rows without claiming them.
+
+Web Push is deliberately outside this outbox.

--- a/migrations/Version20260824_external_notification_outbox.php
+++ b/migrations/Version20260824_external_notification_outbox.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260824_external_notification_outbox extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Transactional external notification outbox and scheduled delivery';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql("CREATE TABLE external_notification_outbox (id INT AUTO_INCREMENT NOT NULL, recipient_id INT NOT NULL, channel VARCHAR(20) NOT NULL, notification_type VARCHAR(50) NOT NULL, dedupe_key VARCHAR(140) NOT NULL, payload JSON NOT NULL, status VARCHAR(20) NOT NULL, attempts INT NOT NULL, available_at DATETIME NOT NULL COMMENT '(DC2Type:datetime_immutable)', locked_at DATETIME DEFAULT NULL COMMENT '(DC2Type:datetime_immutable)', last_error LONGTEXT DEFAULT NULL, created_at DATETIME NOT NULL COMMENT '(DC2Type:datetime_immutable)', sent_at DATETIME DEFAULT NULL COMMENT '(DC2Type:datetime_immutable)', INDEX IDX_external_outbox_recipient (recipient_id), INDEX idx_external_outbox_due (status, available_at), UNIQUE INDEX uniq_external_notification_dedupe (recipient_id, dedupe_key), CONSTRAINT FK_external_outbox_recipient FOREIGN KEY (recipient_id) REFERENCES client (id) ON DELETE CASCADE, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB");
+        $this->addSql("INSERT IGNORE INTO scheduled_command (environment, name, command, schedule, enabled) VALUES ('prod', 'Уведомления: внешняя доставка', 'app:notification:deliver-outbox --no-debug', '* * * * *', 1)");
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql("DELETE FROM scheduled_command WHERE command = 'app:notification:deliver-outbox --no-debug'");
+        $this->addSql('DROP TABLE external_notification_outbox');
+    }
+}

--- a/src/Command/DeliverExternalNotificationsCommand.php
+++ b/src/Command/DeliverExternalNotificationsCommand.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Command;
+
+use App\Entity\ExternalNotificationOutbox;
+use App\Entity\Notification;
+use App\Notification\EmailNotifier;
+use App\Notification\TelegramNotifier;
+use App\Repository\ExternalNotificationOutboxRepository;
+use App\Repository\NotificationSettingsRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand(name: 'app:notification:deliver-outbox', description: 'Deliver pending email and Telegram notification outbox messages')]
+class DeliverExternalNotificationsCommand extends Command
+{
+    public function __construct(
+        private readonly ExternalNotificationOutboxRepository $outbox,
+        private readonly NotificationSettingsRepository $settings,
+        private readonly EmailNotifier $email,
+        private readonly TelegramNotifier $telegram,
+        private readonly EntityManagerInterface $em,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('limit', null, InputOption::VALUE_REQUIRED, 'Maximum messages', '100')
+            ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Report pending messages without claiming or sending them');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $limit = max(1, min(1000, (int) $input->getOption('limit')));
+        if ($input->getOption('dry-run')) {
+            $count = $this->outbox->count(['status' => ExternalNotificationOutbox::STATUS_PENDING]);
+            $output->writeln(sprintf('%d pending external notification(s).', $count));
+            return Command::SUCCESS;
+        }
+
+        $sent = $retried = 0;
+        for ($i = 0; $i < $limit; ++$i) {
+            $now = new \DateTimeImmutable();
+            $message = $this->outbox->claimNext($now);
+            if ($message === null) {
+                break;
+            }
+
+            try {
+                if (!$this->isStillEnabled($message)) {
+                    $message->markSent($now);
+                    $ok = true;
+                } else {
+                    $ok = $this->deliver($message);
+                    $ok ? $message->markSent($now) : $message->retry($now, 'Notifier returned false');
+                }
+            } catch (\Throwable $e) {
+                $ok = false;
+                $message->retry($now, $e->getMessage());
+            }
+            $this->em->flush();
+            $ok ? ++$sent : ++$retried;
+        }
+
+        $output->writeln(sprintf('%d sent/skipped, %d scheduled for retry.', $sent, $retried));
+        return Command::SUCCESS;
+    }
+
+    private function isStillEnabled(ExternalNotificationOutbox $message): bool
+    {
+        $settings = $this->settings->findOneBy([
+            'user' => $message->getRecipient(),
+            'eventType' => $message->getNotificationType(),
+        ]);
+        if ($settings === null) {
+            return $message->getChannel() === Notification::CHANNEL_EMAIL;
+        }
+        return $message->getChannel() === Notification::CHANNEL_EMAIL
+            ? $settings->isChannelEmail()
+            : $settings->isChannelTelegram();
+    }
+
+    private function deliver(ExternalNotificationOutbox $message): bool
+    {
+        $payload = $message->getPayload();
+        if ($message->getChannel() === Notification::CHANNEL_EMAIL) {
+            return $this->email->sendHtml((string) $payload['to'], (string) $payload['name'], (string) $payload['subject'], (string) $payload['html']);
+        }
+        if ($message->getChannel() === Notification::CHANNEL_TELEGRAM) {
+            return $this->telegram->send((string) $payload['chatId'], (string) $payload['text']);
+        }
+        throw new \LogicException('Unsupported external notification channel.');
+    }
+}

--- a/src/Entity/ExternalNotificationOutbox.php
+++ b/src/Entity/ExternalNotificationOutbox.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity;
+
+use App\Repository\ExternalNotificationOutboxRepository;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity(repositoryClass: ExternalNotificationOutboxRepository::class)]
+#[ORM\UniqueConstraint(name: 'uniq_external_notification_dedupe', columns: ['recipient_id', 'dedupe_key'])]
+class ExternalNotificationOutbox
+{
+    public const STATUS_PENDING = 'pending';
+    public const STATUS_PROCESSING = 'processing';
+    public const STATUS_SENT = 'sent';
+    public const STATUS_FAILED = 'failed';
+
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    private ?int $id = null;
+
+    #[ORM\ManyToOne]
+    #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
+    private User $recipient;
+
+    #[ORM\Column(length: 20)]
+    private string $channel;
+
+    #[ORM\Column(length: 50)]
+    private string $notificationType;
+
+    #[ORM\Column(length: 140)]
+    private string $dedupeKey;
+
+    /** @var array<string, mixed> */
+    #[ORM\Column(type: Types::JSON)]
+    private array $payload;
+
+    #[ORM\Column(length: 20)]
+    private string $status = self::STATUS_PENDING;
+
+    #[ORM\Column]
+    private int $attempts = 0;
+
+    #[ORM\Column]
+    private \DateTimeImmutable $availableAt;
+
+    #[ORM\Column(nullable: true)]
+    private ?\DateTimeImmutable $lockedAt = null;
+
+    #[ORM\Column(type: Types::TEXT, nullable: true)]
+    private ?string $lastError = null;
+
+    #[ORM\Column]
+    private \DateTimeImmutable $createdAt;
+
+    #[ORM\Column(nullable: true)]
+    private ?\DateTimeImmutable $sentAt = null;
+
+    /** @param array<string, mixed> $payload */
+    public function __construct(User $recipient, string $channel, string $notificationType, string $dedupeKey, array $payload)
+    {
+        $this->recipient = $recipient;
+        $this->channel = $channel;
+        $this->notificationType = $notificationType;
+        $this->dedupeKey = $dedupeKey;
+        $this->payload = $payload;
+        $this->createdAt = $this->availableAt = new \DateTimeImmutable();
+    }
+
+    public function getId(): ?int { return $this->id; }
+    public function getRecipient(): User { return $this->recipient; }
+    public function getChannel(): string { return $this->channel; }
+    public function getNotificationType(): string { return $this->notificationType; }
+    public function getDedupeKey(): string { return $this->dedupeKey; }
+    /** @return array<string, mixed> */
+    public function getPayload(): array { return $this->payload; }
+    public function getStatus(): string { return $this->status; }
+    public function getAttempts(): int { return $this->attempts; }
+    public function getAvailableAt(): \DateTimeImmutable { return $this->availableAt; }
+
+    public function claim(\DateTimeImmutable $now): void
+    {
+        $this->status = self::STATUS_PROCESSING;
+        $this->lockedAt = $now;
+        ++$this->attempts;
+    }
+
+    public function markSent(\DateTimeImmutable $now): void
+    {
+        $this->status = self::STATUS_SENT;
+        $this->sentAt = $now;
+        $this->lockedAt = null;
+        $this->lastError = null;
+    }
+
+    public function retry(\DateTimeImmutable $now, string $error, int $maxAttempts = 5): void
+    {
+        $this->lockedAt = null;
+        $this->lastError = mb_substr($error, 0, 2000);
+        if ($this->attempts >= $maxAttempts) {
+            $this->status = self::STATUS_FAILED;
+            return;
+        }
+        $this->status = self::STATUS_PENDING;
+        $this->availableAt = $now->modify(sprintf('+%d minutes', min(60, 2 ** $this->attempts)));
+    }
+}

--- a/src/Notification/EmailNotifier.php
+++ b/src/Notification/EmailNotifier.php
@@ -10,6 +10,7 @@ use Symfony\Bridge\Twig\Mime\TemplatedEmail;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\Mailer\MailerInterface;
 use Symfony\Component\Mime\Address;
+use Symfony\Component\Mime\Email;
 
 readonly class EmailNotifier
 {
@@ -90,6 +91,26 @@ readonly class EmailNotifier
                 'error' => $e->getMessage(),
             ]);
 
+            return false;
+        }
+    }
+
+    public function sendHtml(string $recipient, string $recipientName, string $subject, string $html): bool
+    {
+        $to = new Address($recipient, $recipientName);
+        $email = (new Email())
+            ->from($this->fromAddress())
+            ->to($to)
+            ->subject($subject)
+            ->html($html);
+        if ($this->adminEmail !== '' && $recipient !== $this->adminEmail) {
+            $email->replyTo(new Address($this->adminEmail));
+        }
+        try {
+            $this->mailer->send($email);
+            return true;
+        } catch (\Throwable $e) {
+            $this->logger->error('Email notification failed', ['to' => $recipient, 'subject' => $subject, 'error' => $e->getMessage()]);
             return false;
         }
     }

--- a/src/Notification/NotificationDispatcher.php
+++ b/src/Notification/NotificationDispatcher.php
@@ -4,18 +4,19 @@ declare(strict_types=1);
 
 namespace App\Notification;
 
+use App\Entity\ExternalNotificationOutbox;
 use App\Entity\Notification;
 use App\Entity\User;
 use App\Repository\NotificationSettingsRepository;
 use Doctrine\ORM\EntityManagerInterface;
+use Twig\Environment;
 
 readonly class NotificationDispatcher
 {
     public function __construct(
         private EntityManagerInterface $em,
-        private EmailNotifier $emailNotifier,
-        private TelegramNotifier $telegramNotifier,
         private NotificationSettingsRepository $settingsRepo,
+        private Environment $twig,
     ) {}
 
     /**
@@ -29,6 +30,7 @@ readonly class NotificationDispatcher
         ?array $data = null,
         ?string $emailTemplate = null,
         ?array $emailContext = [],
+        ?string $dedupeKey = null,
     ): void {
         $settings = $this->settingsRepo->findOneBy([
             'user' => $recipient,
@@ -41,12 +43,20 @@ readonly class NotificationDispatcher
             'telegram' => $settings ? $settings->isChannelTelegram() : false,
         ];
 
+        $dedupeKey ??= bin2hex(random_bytes(16));
         if ($channels['inapp']) {
-            $this->createInApp($recipient, $type, $title, $body, $data);
+            $this->createInApp($recipient, $type, $title, $body, $data)->setDedupeKey($dedupeKey);
         }
 
         if ($channels['email'] && $emailTemplate) {
-            $this->emailNotifier->send($recipient, $title, $emailTemplate, $emailContext);
+            $context = $emailContext ?? [];
+            $context['user'] = $recipient;
+            $this->em->persist(new ExternalNotificationOutbox($recipient, Notification::CHANNEL_EMAIL, $type, $dedupeKey.':email', [
+                'to' => (string) $recipient->getEmail(),
+                'name' => $recipient->getFullName(),
+                'subject' => $title,
+                'html' => $this->twig->render("emails/{$emailTemplate}.html.twig", $context),
+            ]));
         }
 
         if ($channels['telegram'] && $recipient->getTelegramChatId()) {
@@ -55,7 +65,10 @@ readonly class NotificationDispatcher
             if ($body) {
                 $text .= "\n\n".htmlspecialchars($body, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
             }
-            $this->telegramNotifier->send($recipient->getTelegramChatId(), $text);
+            $this->em->persist(new ExternalNotificationOutbox($recipient, Notification::CHANNEL_TELEGRAM, $type, $dedupeKey.':telegram', [
+                'chatId' => $recipient->getTelegramChatId(),
+                'text' => $text,
+            ]));
         }
     }
 

--- a/src/Repository/ExternalNotificationOutboxRepository.php
+++ b/src/Repository/ExternalNotificationOutboxRepository.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repository;
+
+use App\Entity\ExternalNotificationOutbox;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\DBAL\LockMode;
+use Doctrine\Persistence\ManagerRegistry;
+
+/** @extends ServiceEntityRepository<ExternalNotificationOutbox> */
+class ExternalNotificationOutboxRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, ExternalNotificationOutbox::class);
+    }
+
+    public function claimNext(\DateTimeImmutable $now): ?ExternalNotificationOutbox
+    {
+        return $this->getEntityManager()->wrapInTransaction(function () use ($now): ?ExternalNotificationOutbox {
+            $message = $this->createQueryBuilder('o')
+                ->andWhere('(o.status = :status OR (o.status = :processing AND o.lockedAt < :expired))')
+                ->andWhere('o.availableAt <= :now')
+                ->setParameter('status', ExternalNotificationOutbox::STATUS_PENDING)
+                ->setParameter('processing', ExternalNotificationOutbox::STATUS_PROCESSING)
+                ->setParameter('expired', $now->modify('-10 minutes'))
+                ->setParameter('now', $now)
+                ->orderBy('o.id', 'ASC')
+                ->setMaxResults(1)
+                ->getQuery()
+                ->setLockMode(LockMode::PESSIMISTIC_WRITE)
+                ->getOneOrNullResult();
+
+            $message?->claim($now);
+
+            return $message;
+        });
+    }
+}

--- a/tests/Command/DeliverExternalNotificationsCommandTest.php
+++ b/tests/Command/DeliverExternalNotificationsCommandTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Command;
+
+use App\Command\DeliverExternalNotificationsCommand;
+use App\Entity\ExternalNotificationOutbox;
+use App\Entity\Notification;
+use App\Entity\User;
+use App\Notification\EmailNotifier;
+use App\Notification\TelegramNotifier;
+use App\Repository\ExternalNotificationOutboxRepository;
+use App\Repository\NotificationSettingsRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class DeliverExternalNotificationsCommandTest extends TestCase
+{
+    public function testFailedDeliveryIsRetriedWithoutFailingTheWorker(): void
+    {
+        $user = (new User())->setEmail('parent@example.test');
+        $message = new ExternalNotificationOutbox($user, Notification::CHANNEL_EMAIL, Notification::TYPE_SYSTEM, 'event:email', [
+            'to' => 'parent@example.test', 'name' => 'Parent', 'subject' => 'Subject', 'html' => '<p>Body</p>',
+        ]);
+        $repository = $this->createMock(ExternalNotificationOutboxRepository::class);
+        $calls = 0;
+        $repository->expects($this->exactly(2))->method('claimNext')->willReturnCallback(function (\DateTimeImmutable $now) use ($message, &$calls): ?ExternalNotificationOutbox {
+            if ($calls++ > 0) {
+                return null;
+            }
+            $message->claim($now);
+            return $message;
+        });
+        $settings = $this->createMock(NotificationSettingsRepository::class);
+        $settings->method('findOneBy')->willReturn(null);
+        $email = $this->createMock(EmailNotifier::class);
+        $email->expects($this->once())->method('sendHtml')->willReturn(false);
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->expects($this->once())->method('flush');
+
+        $tester = new CommandTester(new DeliverExternalNotificationsCommand(
+            $repository,
+            $settings,
+            $email,
+            $this->createMock(TelegramNotifier::class),
+            $em,
+        ));
+
+        $this->assertSame(0, $tester->execute([]));
+        $this->assertSame(ExternalNotificationOutbox::STATUS_PENDING, $message->getStatus());
+        $this->assertSame(1, $message->getAttempts());
+        $this->assertStringContainsString('1 scheduled for retry', $tester->getDisplay());
+    }
+}

--- a/tests/Service/NotificationDispatcherTest.php
+++ b/tests/Service/NotificationDispatcherTest.php
@@ -4,23 +4,22 @@ declare(strict_types=1);
 
 namespace App\Tests\Service;
 
+use App\Entity\ExternalNotificationOutbox;
 use App\Entity\Notification;
 use App\Entity\NotificationSettings;
 use App\Entity\User;
-use App\Notification\EmailNotifier;
 use App\Notification\NotificationDispatcher;
-use App\Notification\TelegramNotifier;
 use App\Repository\NotificationSettingsRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\TestCase;
+use Twig\Environment;
 
 class NotificationDispatcherTest extends TestCase
 {
     private User $recipient;
     private EntityManagerInterface $em;
-    private EmailNotifier $emailNotifier;
-    private TelegramNotifier $telegramNotifier;
     private NotificationSettingsRepository $settingsRepo;
+    private Environment $twig;
 
     protected function setUp(): void
     {
@@ -29,18 +28,16 @@ class NotificationDispatcherTest extends TestCase
         $this->recipient->setRoles(['ROLE_BRAND_MANAGER']);
 
         $this->em = $this->createMock(EntityManagerInterface::class);
-        $this->emailNotifier = $this->createMock(EmailNotifier::class);
-        $this->telegramNotifier = $this->createMock(TelegramNotifier::class);
         $this->settingsRepo = $this->createMock(NotificationSettingsRepository::class);
+        $this->twig = $this->createMock(Environment::class);
     }
 
     private function createDispatcher(): NotificationDispatcher
     {
         return new NotificationDispatcher(
             $this->em,
-            $this->emailNotifier,
-            $this->telegramNotifier,
             $this->settingsRepo,
+            $this->twig,
         );
     }
 
@@ -68,8 +65,6 @@ class NotificationDispatcherTest extends TestCase
     {
         $this->settingsRepo->method('findOneBy')->willReturn(null);
 
-        $this->emailNotifier->expects($this->never())->method('send');
-
         $this->createDispatcher()->dispatch(
             $this->recipient,
             Notification::TYPE_ORDER_NEW,
@@ -79,14 +74,18 @@ class NotificationDispatcherTest extends TestCase
         $this->assertTrue(true);
     }
 
-    public function testDispatchSendsEmailWhenTemplateProvided(): void
+    public function testDispatchQueuesRenderedEmailWithoutSendingIt(): void
     {
         $this->settingsRepo->method('findOneBy')->willReturn(null);
-        $this->em->method('persist');
-        $this->em->method('flush');
-
-        $this->emailNotifier->expects($this->once())->method('send')
-            ->with($this->recipient, 'Test email', 'new_order_brand', ['order' => 'stub']);
+        $this->twig->expects($this->once())->method('render')->willReturn('<p>safe</p>');
+        $queued = $inApp = null;
+        $this->em->expects($this->exactly(2))->method('persist')->willReturnCallback(function (object $entity) use (&$queued, &$inApp): void {
+            if ($entity instanceof ExternalNotificationOutbox) {
+                $queued = $entity;
+            } elseif ($entity instanceof Notification) {
+                $inApp = $entity;
+            }
+        });
 
         $this->createDispatcher()->dispatch(
             $this->recipient,
@@ -96,7 +95,12 @@ class NotificationDispatcherTest extends TestCase
             null,
             'new_order_brand',
             ['order' => 'stub'],
+            'order:1',
         );
+        $this->assertInstanceOf(ExternalNotificationOutbox::class, $queued);
+        $this->assertSame('<p>safe</p>', $queued->getPayload()['html']);
+        $this->assertSame('order:1', $inApp->getDedupeKey());
+        $this->assertSame('order:1:email', $queued->getDedupeKey());
     }
 
     public function testDispatchRespectsSettingsInappDisabled(): void
@@ -116,7 +120,7 @@ class NotificationDispatcherTest extends TestCase
         );
     }
 
-    public function testDispatchSendsTelegramWhenEnabled(): void
+    public function testDispatchQueuesEscapedTelegramWhenEnabled(): void
     {
         $this->recipient->setTelegramChatId('12345');
 
@@ -127,14 +131,19 @@ class NotificationDispatcherTest extends TestCase
 
         $this->settingsRepo->method('findOneBy')->willReturn($settings);
 
-        $this->telegramNotifier->expects($this->once())->method('send')
-            ->with('12345', $this->stringContains('Test telegram'));
+        $queued = null;
+        $this->em->expects($this->once())->method('persist')->willReturnCallback(function (object $entity) use (&$queued): void {
+            $queued = $entity;
+        });
 
         $this->createDispatcher()->dispatch(
             $this->recipient,
             Notification::TYPE_ORDER_NEW,
-            'Test telegram',
+            '<script>telegram & test</script>',
         );
+        $this->assertInstanceOf(ExternalNotificationOutbox::class, $queued);
+        $this->assertStringNotContainsString('<script>', $queued->getPayload()['text']);
+        $this->assertStringContainsString('&lt;script&gt;', $queued->getPayload()['text']);
     }
 
     public function testDispatchSkipsTelegramWhenNoChatId(): void
@@ -145,7 +154,7 @@ class NotificationDispatcherTest extends TestCase
 
         $this->settingsRepo->method('findOneBy')->willReturn($settings);
 
-        $this->telegramNotifier->expects($this->never())->method('send');
+        $this->em->expects($this->once())->method('persist')->with($this->isInstanceOf(Notification::class));
 
         $this->createDispatcher()->dispatch(
             $this->recipient,


### PR DESCRIPTION
## Что сделано
- email/Telegram сохраняются в transactional outbox рядом с in-app notification; сетевых вызовов в доменной транзакции больше нет
- email HTML и экранированный Telegram HTML snapshot сохраняются безопасно без сериализации Doctrine entities
- scheduled command доставляет после commit, повторяет сбои с backoff, восстанавливает stale claims и изолирует ошибки сообщений
- preferences проверяются при enqueue и повторно перед отправкой; Web Push не добавлялся
- dedupe связывает in-app событие и channel-specific outbox rows

## Проверки
- `./vendor/bin/phpunit tests/Service/NotificationDispatcherTest.php tests/Command/DeliverExternalNotificationsCommandTest.php` — OK (7 tests, 23 assertions)
- `php -d memory_limit=512M bin/console lint:twig templates/emails` — OK
- `php -d memory_limit=512M bin/console doctrine:mapping:info` — OK
- full suite: 752/753 pass; unrelated existing asset-install failure in `RagBrandPanelTest` (`@hotwired/stimulus` missing in fresh worktree)
- `git diff --check` — OK