### PR TITLE
fix: reuse existing push notification setting

### DIFF
--- a/migrations/Version20260824_family_web_push.php
+++ b/migrations/Version20260824_family_web_push.php
@@ -16,7 +16,6 @@ final class Version20260824_family_web_push extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        $this->addSql('ALTER TABLE notification_settings ADD channel_push TINYINT(1) DEFAULT 0 NOT NULL');
         $this->addSql('CREATE TABLE web_push_subscription (id INT AUTO_INCREMENT NOT NULL, user_id INT NOT NULL, endpoint LONGTEXT NOT NULL, endpoint_hash VARCHAR(64) NOT NULL, public_key LONGTEXT NOT NULL, auth_token LONGTEXT NOT NULL, content_encoding VARCHAR(20) DEFAULT NULL, revoked_at DATETIME DEFAULT NULL COMMENT \'(DC2Type:datetime_immutable)\', created_at DATETIME NOT NULL COMMENT \'(DC2Type:datetime_immutable)\', UNIQUE INDEX uniq_web_push_endpoint (endpoint_hash), INDEX IDX_WEB_PUSH_USER (user_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
         $this->addSql('ALTER TABLE web_push_subscription ADD CONSTRAINT FK_WEB_PUSH_USER FOREIGN KEY (user_id) REFERENCES client (id) ON DELETE CASCADE');
     }
@@ -24,6 +23,5 @@ final class Version20260824_family_web_push extends AbstractMigration
     public function down(Schema $schema): void
     {
         $this->addSql('DROP TABLE web_push_subscription');
-        $this->addSql('ALTER TABLE notification_settings DROP channel_push');
     }
 }


### PR DESCRIPTION
Removes the duplicate channel_push DDL from the Web Push migration: the column has existed since the account notification settings migration. Keeps the new subscription table migration and prevents production deploy failure.\n\nChecks: migration PHP lint, Doctrine mapping, focused Web Push tests, diff check.