### PR TITLE
fix: provide fail-closed BrandActionSigner secret default

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -14,6 +14,7 @@ parameters:
     env(BRAND_CLAIM_AUTOGRANT_EMAIL): '1'
     env(BRAND_CLAIM_AUTOGRANT_VK): '1'
     env(PAYMENT_SECRET_KEY): ''
+    env(AGENT_API_SECRET): ''
     env(WEB_PUSH_PUBLIC_KEY): ''
     env(WEB_PUSH_PRIVATE_KEY): ''
     env(WEB_PUSH_SUBJECT): 'mailto:admin@wearbase.ru'

--- a/src/Service/BrandActionSigner.php
+++ b/src/Service/BrandActionSigner.php
@@ -23,7 +23,7 @@ use Symfony\Component\DependencyInjection\Attribute\Autowire;
 class BrandActionSigner
 {
     public function __construct(
-        #[Autowire('%env(default::AGENT_API_SECRET)%')]
+        #[Autowire('%env(AGENT_API_SECRET)%')]
         private readonly string $secret,
     ) {
     }


### PR DESCRIPTION
## Root cause
`BrandActionSigner` used `%env(default::AGENT_API_SECRET)%`. The empty middle segment of Symfony’s `default` processor means an explicit `null` fallback; it does not refer to `env(AGENT_API_SECRET)`. With the env absent, DI therefore injected `null` into a strict `string` constructor and `lint:container` failed.

## Fix
- define the project-standard optional env fallback `env(AGENT_API_SECRET): ""`
- inject `%env(AGENT_API_SECRET)%` into this signer
- retain the strict `string` signature and existing fail-closed behavior: empty secret cannot sign and cannot verify

No secret value is committed or exposed.

## Check
`php -d memory_limit=512M bin/console lint:container` — OK