### PR TITLE
feat: add native device management

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -129,6 +129,7 @@ cp ops/com.wearbase.cron.plist ~/Library/LaunchAgents/ \
 |---|---|---|---|
 | `app:wardrobe:ingest-drafts` | Фоновое vision-распознавание приватных batch-drafts с lease/retry. | ⏰ `*/2 * * * *` | ☁️ prod |
 | `app:wardrobe:cleanup-drafts` | Через 7 дней очищает photo/`ai_raw` accepted receipts; через 30 дней удаляет abandoned drafts. `--dry-run`. | ⏰ `17 3 * * *` | ☁️ prod |
+| `app:native-auth:cleanup` | Удаляет истёкшие refresh receipts, отозванные native device sessions и sessions без действующего refresh. | ⏰ `43 3 * * *` | ☁️ prod |
 | `app:wardrobe:ingest-health` | Очередь, oldest pending, expired lease, failed/retry, storage и последний scheduler run. `--json`, `--check`. Подробнее: [операционная проверка](wardrobe_ingest_operations.md). | 👆 smoke/monitoring | ☁️ prod |
 | `app:family:purchase-reminders` | Только in-app: раз в локальный день напоминает родителям о pending-запросах, а родителям и активированному ребёнку — о delivered-позициях без результата примерки. `--dry-run`, `--now=ISO-8601`; граница дня — Europe/Moscow, дедуп — состояние/объект/дата/получатель. | ⏰ `15 9 * * *` | ☁️ prod |
 | `app:contacts:refresh` | Актуализация контактов из RAG-корпуса (новый конвейер, см. `_docs/contacts-refresh-plan.md`). TTL-ревалидация, демон-режим. | ⏰/🔁 | 🖥 .43 |

--- a/docs/native_device_auth.md
+++ b/docs/native_device_auth.md
@@ -9,12 +9,15 @@ PWA продолжает работать с существующей Symfony se
 POST /api/v1/wardrobe-app/auth/login
 Content-Type: application/json
 
-{"email":"user@example.com","password":"...","deviceId":"ios-installation-uuid"}
+{"email":"user@example.com","password":"...","deviceId":"ios-installation-uuid","deviceLabel":"iphone"}
 ```
 
 Ответ содержит короткоживущий access token (15 минут) и refresh token (30 дней). Клиент обязан
 хранить их в iOS Keychain, не в `UserDefaults`, логах или аналитике. `deviceId` — случайный стабильный
 идентификатор установки длиной 8–128 символов, не IDFA и не аппаратный fingerprint.
+`deviceLabel` необязателен и принимает только `iphone|ipad|mac|android|other`: произвольное имя
+устройства не сохраняется. Ответ содержит случайный `device.publicId` для управления устройствами;
+внутренний ID БД клиенту не выдаётся.
 
 Access передаётся стандартно:
 
@@ -37,12 +40,21 @@ Authorization: Bearer <accessToken>
 
 POST /api/v1/wardrobe-app/auth/revoke-all
 Authorization: Bearer <accessToken>
+
+GET /api/v1/wardrobe-app/auth/devices
+Authorization: Bearer <accessToken>
+
+DELETE /api/v1/wardrobe-app/auth/devices/{publicId}
+Authorization: Bearer <accessToken>
 ```
 
 Каждый refresh одноразовый и атомарно заменяет access и refresh. Повторное предъявление уже
 использованного refresh считается reuse: вся device session отзывается, включая новый access.
 `revoke` отзывает текущее устройство, `revoke-all` — все устройства пользователя. Оба endpoint
 требуют native Bearer-контекст и не принимают одну лишь browser cookie, поэтому не создают CSRF-path.
+Список устройств содержит только собственные label, `createdAt`, `lastUsedAt`, `revokedAt` и `current`.
+Удаление позволяет отозвать текущее или другое устройство; чужой и неизвестный opaque ID одинаково
+возвращают `404`.
 
 Повторный login с тем же `deviceId` отзывает прежнюю сессию установки. Заблокированные пользователи
 не могут получить токены. Family authorization после аутентификации остаётся в `FamilyService`, как
@@ -60,3 +72,10 @@ Authorization: Bearer <accessToken>
 
 Не помещать токены в query string. OIDC/social sign-in и фоновые push credentials не входят в этот
 атомарный контур и должны добавляться отдельным threat-model/PR.
+
+## Retention
+
+Успешная bearer-аутентификация обновляет `lastUsedAt`. `app:native-auth:cleanup` ежедневно в 03:43
+на prod удаляет истёкшие refresh-receipts, отозванные sessions и sessions без действующего refresh.
+Действующая refresh-сессия не удаляется только из-за 15-минутного expiry access. Команда идемпотентна
+и выводит лишь агрегированные количества — без raw tokens и hashes.

--- a/migrations/Version20260824_native_device_management.php
+++ b/migrations/Version20260824_native_device_management.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260824_native_device_management extends AbstractMigration
+{
+    public function getDescription(): string { return 'Opaque native device identity, safe label, activity timestamp and cleanup schedule'; }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql("ALTER TABLE native_device_session ADD public_id VARCHAR(32) DEFAULT NULL, ADD device_label VARCHAR(16) DEFAULT 'other' NOT NULL, ADD last_used_at DATETIME DEFAULT NULL COMMENT '(DC2Type:datetime_immutable)'");
+        $this->addSql("UPDATE native_device_session SET public_id = REPLACE(UUID(), '-', '') WHERE public_id IS NULL");
+        $this->addSql('ALTER TABLE native_device_session MODIFY public_id VARCHAR(32) NOT NULL');
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_NATIVE_DEVICE_PUBLIC_ID ON native_device_session (public_id)');
+        $this->addSql("INSERT IGNORE INTO scheduled_command (environment, name, command, schedule, enabled) VALUES ('prod', 'Native auth: очистка устройств', 'app:native-auth:cleanup --no-debug', '43 3 * * *', 1)");
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql("DELETE FROM scheduled_command WHERE command = 'app:native-auth:cleanup --no-debug'");
+        $this->addSql('DROP INDEX UNIQ_NATIVE_DEVICE_PUBLIC_ID ON native_device_session');
+        $this->addSql('ALTER TABLE native_device_session DROP public_id, DROP device_label, DROP last_used_at');
+    }
+}

--- a/src/Command/CleanupNativeDeviceAuthCommand.php
+++ b/src/Command/CleanupNativeDeviceAuthCommand.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Command;
+
+use App\Repository\NativeDeviceSessionRepository;
+use App\Repository\NativeRefreshTokenRepository;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand(name: 'app:native-auth:cleanup', description: 'Удаляет истёкшие native refresh receipts и завершённые device sessions')]
+final class CleanupNativeDeviceAuthCommand extends Command
+{
+    public function __construct(
+        private readonly NativeRefreshTokenRepository $refreshTokens,
+        private readonly NativeDeviceSessionRepository $sessions,
+    ) {
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $now = new \DateTimeImmutable();
+        $receipts = $this->refreshTokens->deleteExpired($now);
+        $revoked = $this->sessions->deleteRevokedBefore($now);
+        $expired = $this->sessions->deleteExpiredWithoutRefresh($now);
+        $output->writeln(sprintf(
+            'Deleted %d expired refresh receipt(s), %d revoked session(s), %d expired session(s).',
+            $receipts,
+            $revoked,
+            $expired,
+        ));
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Controller/Api/NativeDeviceAuthController.php
+++ b/src/Controller/Api/NativeDeviceAuthController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Controller\Api;
 
+use App\Entity\NativeDeviceSession;
 use App\Entity\User;
 use App\Service\NativeDeviceAuth;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -29,15 +30,46 @@ final class NativeDeviceAuthController extends AbstractController
         }
         $password = is_string($data['password'] ?? null) ? $data['password'] : '';
         $deviceId = is_string($data['deviceId'] ?? null) ? trim($data['deviceId']) : '';
+        $deviceLabel = is_string($data['deviceLabel'] ?? null) ? trim($data['deviceLabel']) : NativeDeviceSession::LABEL_OTHER;
         if ($email === '' || $password === '' || strlen($password) > 4096 || strlen($deviceId) < 8 || strlen($deviceId) > 128) {
             return $this->jsonPrivate(['error' => 'invalid_credentials'], Response::HTTP_UNAUTHORIZED);
         }
+        if (!in_array($deviceLabel, NativeDeviceSession::LABELS, true)) {
+            return $this->jsonPrivate(['error' => 'invalid_device_label'], Response::HTTP_BAD_REQUEST);
+        }
 
         try {
-            return $this->jsonPrivate($this->auth->login($email, $password, $deviceId));
+            return $this->jsonPrivate($this->auth->login($email, $password, $deviceId, $deviceLabel));
         } catch (\DomainException) {
             return $this->jsonPrivate(['error' => 'invalid_credentials'], Response::HTTP_UNAUTHORIZED);
         }
+    }
+
+    #[Route('/devices', name: 'devices', methods: ['GET'])]
+    public function devices(Request $request): JsonResponse
+    {
+        $user = $this->nativeUser($request);
+        if ($user === null) {
+            return $this->jsonPrivate(['error' => 'native_authentication_required'], Response::HTTP_UNAUTHORIZED);
+        }
+
+        return $this->jsonPrivate(['devices' => $this->auth->devices($user, $request->attributes->getInt('_native_device_session_id'))]);
+    }
+
+    #[Route('/devices/{publicId}', name: 'revoke_device', requirements: ['publicId' => '[a-f0-9]{32}'], methods: ['DELETE'])]
+    public function revokeDevice(string $publicId, Request $request): JsonResponse
+    {
+        $user = $this->nativeUser($request);
+        if ($user === null) {
+            return $this->jsonPrivate(['error' => 'native_authentication_required'], Response::HTTP_UNAUTHORIZED);
+        }
+        try {
+            $this->auth->revokeByPublicId($publicId, $user);
+        } catch (\DomainException) {
+            return $this->jsonPrivate(['error' => 'device_not_found'], Response::HTTP_NOT_FOUND);
+        }
+
+        return $this->jsonPrivate(['ok' => true]);
     }
 
     #[Route('/refresh', name: 'refresh', methods: ['POST'])]
@@ -97,5 +129,12 @@ final class NativeDeviceAuthController extends AbstractController
     private function jsonPrivate(array $data, int $status = Response::HTTP_OK): JsonResponse
     {
         return $this->json($data, $status, ['Cache-Control' => 'no-store, private']);
+    }
+
+    private function nativeUser(Request $request): ?User
+    {
+        $user = $this->getUser();
+
+        return $user instanceof User && $request->attributes->getInt('_native_device_session_id') > 0 ? $user : null;
     }
 }

--- a/src/Entity/NativeDeviceSession.php
+++ b/src/Entity/NativeDeviceSession.php
@@ -14,6 +14,9 @@ use Doctrine\ORM\Mapping as ORM;
 #[ORM\Index(name: 'idx_native_session_user_device', columns: ['user_id', 'device_hash'])]
 class NativeDeviceSession
 {
+    public const LABEL_OTHER = 'other';
+    public const LABELS = ['iphone', 'ipad', 'mac', 'android', self::LABEL_OTHER];
+
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column]
@@ -22,6 +25,12 @@ class NativeDeviceSession
     #[ORM\ManyToOne]
     #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
     private User $user;
+
+    #[ORM\Column(name: 'public_id', length: 32, unique: true)]
+    private string $publicId;
+
+    #[ORM\Column(name: 'device_label', length: 16, options: ['default' => self::LABEL_OTHER])]
+    private string $deviceLabel;
 
     #[ORM\Column(name: 'device_hash', length: 64)]
     private string $deviceHash;
@@ -38,13 +47,21 @@ class NativeDeviceSession
     #[ORM\Column]
     private \DateTimeImmutable $createdAt;
 
+    #[ORM\Column(nullable: true)]
+    private ?\DateTimeImmutable $lastUsedAt = null;
+
     /** @var Collection<int, NativeRefreshToken> */
     #[ORM\OneToMany(targetEntity: NativeRefreshToken::class, mappedBy: 'session', cascade: ['persist'], orphanRemoval: true)]
     private Collection $refreshTokens;
 
-    public function __construct(User $user, string $deviceHash, string $accessHash, \DateTimeImmutable $accessExpiresAt)
+    public function __construct(User $user, string $deviceHash, string $accessHash, \DateTimeImmutable $accessExpiresAt, string $deviceLabel = self::LABEL_OTHER)
     {
+        if (!in_array($deviceLabel, self::LABELS, true)) {
+            throw new \InvalidArgumentException('Unknown device label');
+        }
         $this->user = $user;
+        $this->publicId = bin2hex(random_bytes(16));
+        $this->deviceLabel = $deviceLabel;
         $this->deviceHash = $deviceHash;
         $this->accessHash = $accessHash;
         $this->accessExpiresAt = $accessExpiresAt;
@@ -54,10 +71,14 @@ class NativeDeviceSession
 
     public function getId(): ?int { return $this->id; }
     public function getUser(): User { return $this->user; }
+    public function getPublicId(): string { return $this->publicId; }
+    public function getDeviceLabel(): string { return $this->deviceLabel; }
     public function getDeviceHash(): string { return $this->deviceHash; }
     public function getAccessHash(): string { return $this->accessHash; }
     public function getAccessExpiresAt(): \DateTimeImmutable { return $this->accessExpiresAt; }
     public function getRevokedAt(): ?\DateTimeImmutable { return $this->revokedAt; }
+    public function getCreatedAt(): \DateTimeImmutable { return $this->createdAt; }
+    public function getLastUsedAt(): ?\DateTimeImmutable { return $this->lastUsedAt; }
     public function isRevoked(): bool { return $this->revokedAt !== null; }
 
     public function rotateAccess(string $accessHash, \DateTimeImmutable $expiresAt): void
@@ -67,6 +88,8 @@ class NativeDeviceSession
     }
 
     public function revoke(): void { $this->revokedAt ??= new \DateTimeImmutable(); }
+
+    public function touch(?\DateTimeImmutable $at = null): void { $this->lastUsedAt = $at ?? new \DateTimeImmutable(); }
 
     public function addRefreshToken(NativeRefreshToken $token): void
     {

--- a/src/Repository/NativeDeviceSessionRepository.php
+++ b/src/Repository/NativeDeviceSessionRepository.php
@@ -32,4 +32,37 @@ final class NativeDeviceSessionRepository extends ServiceEntityRepository
     {
         return $this->findBy(['user' => $user, 'revokedAt' => null]);
     }
+
+    /** @return NativeDeviceSession[] */
+    public function findForUser(User $user): array
+    {
+        return $this->findBy(['user' => $user], ['createdAt' => 'DESC']);
+    }
+
+    public function findOwnedByPublicId(User $user, string $publicId): ?NativeDeviceSession
+    {
+        return $this->findOneBy(['user' => $user, 'publicId' => $publicId]);
+    }
+
+    public function touchLastUsed(NativeDeviceSession $session, \DateTimeImmutable $at): void
+    {
+        $this->getEntityManager()->getConnection()->update('native_device_session',
+            ['last_used_at' => $at->format('Y-m-d H:i:s')],
+            ['id' => $session->getId()],
+        );
+        $session->touch($at);
+    }
+
+    public function deleteRevokedBefore(\DateTimeImmutable $cutoff): int
+    {
+        return $this->createQueryBuilder('s')->delete()->andWhere('s.revokedAt <= :cutoff')
+            ->setParameter('cutoff', $cutoff)->getQuery()->execute();
+    }
+
+    public function deleteExpiredWithoutRefresh(\DateTimeImmutable $now): int
+    {
+        return $this->getEntityManager()->createQuery(
+            'DELETE FROM App\Entity\NativeDeviceSession s WHERE s.revokedAt IS NULL AND s.accessExpiresAt <= :now AND NOT EXISTS (SELECT t.id FROM App\Entity\NativeRefreshToken t WHERE IDENTITY(t.session) = s.id AND t.expiresAt > :now)',
+        )->setParameter('now', $now)->execute();
+    }
 }

--- a/src/Repository/NativeRefreshTokenRepository.php
+++ b/src/Repository/NativeRefreshTokenRepository.php
@@ -19,4 +19,10 @@ final class NativeRefreshTokenRepository extends ServiceEntityRepository
         return $this->createQueryBuilder('t')->andWhere('t.tokenHash = :hash')->setParameter('hash', $hash)
             ->getQuery()->setLockMode(LockMode::PESSIMISTIC_WRITE)->getOneOrNullResult();
     }
+
+    public function deleteExpired(\DateTimeImmutable $now): int
+    {
+        return $this->createQueryBuilder('t')->delete()->andWhere('t.expiresAt <= :now')
+            ->setParameter('now', $now)->getQuery()->execute();
+    }
 }

--- a/src/Service/NativeDeviceAuth.php
+++ b/src/Service/NativeDeviceAuth.php
@@ -27,8 +27,8 @@ final class NativeDeviceAuth
         private readonly EntityManagerInterface $em,
     ) {}
 
-    /** @return array{accessToken:string,accessExpiresAt:string,refreshToken:string,refreshExpiresAt:string} */
-    public function login(string $email, string $password, string $deviceId): array
+    /** @return array{accessToken:string,accessExpiresAt:string,refreshToken:string,refreshExpiresAt:string,device:array{publicId:string,label:string}} */
+    public function login(string $email, string $password, string $deviceId, string $deviceLabel = NativeDeviceSession::LABEL_OTHER): array
     {
         $email = mb_strtolower(trim($email));
         $user = $this->users->findOneBy(['email' => $email]);
@@ -39,14 +39,14 @@ final class NativeDeviceAuth
             throw new \DomainException('invalid_credentials');
         }
 
-        return $this->em->wrapInTransaction(function () use ($user, $deviceId): array {
+        return $this->em->wrapInTransaction(function () use ($user, $deviceId, $deviceLabel): array {
             $this->em->lock($user, LockMode::PESSIMISTIC_WRITE);
             $deviceHash = $this->hash($deviceId);
             foreach ($this->sessions->findActiveForDevice($user, $deviceHash) as $existing) {
                 $existing->revoke();
             }
 
-            return $this->issue($user, $deviceHash);
+            return $this->issue($user, $deviceHash, $deviceLabel);
         });
     }
 
@@ -73,6 +73,7 @@ final class NativeDeviceAuth
             [$access, $accessExpiresAt] = $this->newToken(self::ACCESS_TTL, 32);
             [$refresh, $refreshExpiresAt] = $this->newToken(self::REFRESH_TTL, 48);
             $session->rotateAccess($this->hash($access), $accessExpiresAt);
+            $session->touch();
             $next = new NativeRefreshToken($session, $this->hash($refresh), $refreshExpiresAt);
             $session->addRefreshToken($next);
             $this->em->persist($next);
@@ -90,8 +91,36 @@ final class NativeDeviceAuth
     public function authenticateAccess(string $rawAccessToken): ?NativeDeviceSession
     {
         $session = $this->sessions->findValidAccess($this->hash($rawAccessToken), new \DateTimeImmutable());
+        if ($session?->getUser()->getStatus() === 'active') {
+            $this->sessions->touchLastUsed($session, new \DateTimeImmutable());
 
-        return $session?->getUser()->getStatus() === 'active' ? $session : null;
+            return $session;
+        }
+
+        return null;
+    }
+
+    /** @return array<int, array{publicId:string,label:string,createdAt:string,lastUsedAt:?string,revokedAt:?string,current:bool}> */
+    public function devices(User $user, int $currentSessionId): array
+    {
+        return array_map(static fn (NativeDeviceSession $session): array => [
+            'publicId' => $session->getPublicId(),
+            'label' => $session->getDeviceLabel(),
+            'createdAt' => $session->getCreatedAt()->format(DATE_ATOM),
+            'lastUsedAt' => $session->getLastUsedAt()?->format(DATE_ATOM),
+            'revokedAt' => $session->getRevokedAt()?->format(DATE_ATOM),
+            'current' => $session->getId() === $currentSessionId,
+        ], $this->sessions->findForUser($user));
+    }
+
+    public function revokeByPublicId(string $publicId, User $user): void
+    {
+        $session = $this->sessions->findOwnedByPublicId($user, $publicId);
+        if ($session === null) {
+            throw new \DomainException('invalid_device_session');
+        }
+        $session->revoke();
+        $this->em->flush();
     }
 
     public function revokeSession(int $sessionId, User $user): void
@@ -112,19 +141,19 @@ final class NativeDeviceAuth
         $this->em->flush();
     }
 
-    /** @return array{accessToken:string,accessExpiresAt:string,refreshToken:string,refreshExpiresAt:string} */
-    private function issue(User $user, string $deviceHash): array
+    /** @return array{accessToken:string,accessExpiresAt:string,refreshToken:string,refreshExpiresAt:string,device:array{publicId:string,label:string}} */
+    private function issue(User $user, string $deviceHash, string $deviceLabel): array
     {
         [$access, $accessExpiresAt] = $this->newToken(self::ACCESS_TTL, 32);
         [$refresh, $refreshExpiresAt] = $this->newToken(self::REFRESH_TTL, 48);
-        $session = new NativeDeviceSession($user, $deviceHash, $this->hash($access), $accessExpiresAt);
+        $session = new NativeDeviceSession($user, $deviceHash, $this->hash($access), $accessExpiresAt, $deviceLabel);
         $refreshEntity = new NativeRefreshToken($session, $this->hash($refresh), $refreshExpiresAt);
         $session->addRefreshToken($refreshEntity);
         $this->em->persist($session);
         $this->em->persist($refreshEntity);
         $this->em->flush();
 
-        return $this->response($access, $accessExpiresAt, $refresh, $refreshExpiresAt);
+        return $this->response($access, $accessExpiresAt, $refresh, $refreshExpiresAt, $session);
     }
 
     /** @return array{0:string,1:\DateTimeImmutable} */
@@ -133,15 +162,20 @@ final class NativeDeviceAuth
         return [rtrim(strtr(base64_encode(random_bytes($bytes)), '+/', '-_'), '='), new \DateTimeImmutable("+{$ttl} seconds")];
     }
 
-    /** @return array{accessToken:string,accessExpiresAt:string,refreshToken:string,refreshExpiresAt:string} */
-    private function response(string $access, \DateTimeImmutable $accessExpiresAt, string $refresh, \DateTimeImmutable $refreshExpiresAt): array
+    /** @return array{accessToken:string,accessExpiresAt:string,refreshToken:string,refreshExpiresAt:string,device?:array{publicId:string,label:string}} */
+    private function response(string $access, \DateTimeImmutable $accessExpiresAt, string $refresh, \DateTimeImmutable $refreshExpiresAt, ?NativeDeviceSession $session = null): array
     {
-        return [
+        $response = [
             'accessToken' => $access,
             'accessExpiresAt' => $accessExpiresAt->format(DATE_ATOM),
             'refreshToken' => $refresh,
             'refreshExpiresAt' => $refreshExpiresAt->format(DATE_ATOM),
         ];
+        if ($session !== null) {
+            $response['device'] = ['publicId' => $session->getPublicId(), 'label' => $session->getDeviceLabel()];
+        }
+
+        return $response;
     }
 
     private function hash(string $value): string { return hash('sha256', $value); }

--- a/tests/Command/CleanupNativeDeviceAuthCommandTest.php
+++ b/tests/Command/CleanupNativeDeviceAuthCommandTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Command;
+
+use App\Tests\Controller\AuthenticatedWebTestCase;
+use App\Tests\Controller\UserFactory;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+
+final class CleanupNativeDeviceAuthCommandTest extends AuthenticatedWebTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->skipIfNoDatabase();
+    }
+
+    public function testCleanupRemovesOnlyFinishedCredentialsAndIsIdempotentWithoutLeakingTokens(): void
+    {
+        $client = static::createClient();
+        $tester = new CommandTester((new Application(self::$kernel))->find('app:native-auth:cleanup'));
+        $tester->execute([]);
+        $user = UserFactory::withEmail(static::getContainer(), 'native-cleanup-'.bin2hex(random_bytes(5)).'@test.local');
+        $revoked = $this->login($client, $user->getEmail(), 'cleanup-revoked');
+        $expired = $this->login($client, $user->getEmail(), 'cleanup-expired');
+        $live = $this->login($client, $user->getEmail(), 'cleanup-live');
+        $connection = static::getContainer()->get('doctrine.orm.entity_manager')->getConnection();
+        $past = (new \DateTimeImmutable('-1 day'))->format('Y-m-d H:i:s');
+        $connection->executeStatement('UPDATE native_device_session SET revoked_at = ? WHERE public_id = ?', [$past, $revoked['device']['publicId']]);
+        $connection->executeStatement('UPDATE native_device_session SET access_expires_at = ? WHERE public_id IN (?, ?)', [$past, $expired['device']['publicId'], $live['device']['publicId']]);
+        $connection->executeStatement('UPDATE native_refresh_token SET expires_at = ? WHERE session_id = (SELECT id FROM native_device_session WHERE public_id = ?)', [$past, $expired['device']['publicId']]);
+
+        self::assertSame(0, $tester->execute([]));
+        self::assertStringContainsString('1 expired refresh receipt(s), 1 revoked session(s), 1 expired session(s)', $tester->getDisplay());
+        self::assertStringNotContainsString($revoked['accessToken'], $tester->getDisplay());
+        self::assertStringNotContainsString($expired['refreshToken'], $tester->getDisplay());
+        self::assertFalse((bool) $connection->fetchOne('SELECT COUNT(*) FROM native_device_session WHERE public_id IN (?, ?)', [$revoked['device']['publicId'], $expired['device']['publicId']]));
+        self::assertSame(1, (int) $connection->fetchOne('SELECT COUNT(*) FROM native_device_session WHERE public_id = ?', [$live['device']['publicId']]));
+
+        self::assertSame(0, $tester->execute([]));
+        self::assertStringContainsString('0 expired refresh receipt(s), 0 revoked session(s), 0 expired session(s)', $tester->getDisplay());
+    }
+
+    /** @return array<string, mixed> */
+    private function login($client, string $email, string $deviceId): array
+    {
+        $client->jsonRequest('POST', '/api/v1/wardrobe-app/auth/login', [
+            'email' => $email, 'password' => UserFactory::PASSWORD, 'deviceId' => $deviceId,
+        ]);
+        self::assertResponseIsSuccessful();
+
+        return json_decode((string) $client->getResponse()->getContent(), true, flags: JSON_THROW_ON_ERROR);
+    }
+}

--- a/tests/Controller/Api/NativeDeviceAuthControllerTest.php
+++ b/tests/Controller/Api/NativeDeviceAuthControllerTest.php
@@ -32,9 +32,9 @@ final class NativeDeviceAuthControllerTest extends AuthenticatedWebTestCase
 
         $connection = static::getContainer()->get('doctrine.orm.entity_manager')->getConnection();
         $row = $connection->fetchAssociative('SELECT access_hash FROM native_device_session WHERE user_id = ?', [$user->getId()]);
-        $refreshHash = $connection->fetchOne('SELECT token_hash FROM native_refresh_token');
+        $matchingRefreshHashes = $connection->fetchOne('SELECT COUNT(*) FROM native_refresh_token WHERE token_hash = ?', [hash('sha256', $tokens['refreshToken'])]);
         self::assertSame(hash('sha256', $tokens['accessToken']), $row['access_hash']);
-        self::assertSame(hash('sha256', $tokens['refreshToken']), $refreshHash);
+        self::assertSame(1, (int) $matchingRefreshHashes);
         self::assertNotSame($tokens['accessToken'], $row['access_hash']);
 
         $this->bearer($client, $tokens['accessToken'], '/api/v1/wardrobe-app/bootstrap');
@@ -197,11 +197,74 @@ final class NativeDeviceAuthControllerTest extends AuthenticatedWebTestCase
         }
     }
 
-    /** @return array<string, string> */
-    private function login(KernelBrowser $client, User $user, string $deviceId = 'iphone-test-device', string $password = UserFactory::PASSWORD): array
+    public function testDeviceListUsesOpaqueIdsAllowlistedLabelsAndTracksLastUse(): void
+    {
+        $client = static::createClient();
+        $user = UserFactory::withEmail(static::getContainer(), $this->email('device-list'));
+        $first = $this->login($client, $user, 'iphone-list-one', UserFactory::PASSWORD, 'iphone');
+        $second = $this->login($client, $user, 'ipad-list-two', UserFactory::PASSWORD, 'ipad');
+
+        self::assertMatchesRegularExpression('/^[a-f0-9]{32}$/', $first['device']['publicId']);
+        self::assertSame('iphone', $first['device']['label']);
+        self::assertNotSame((string) $user->getId(), $first['device']['publicId']);
+        $this->bearer($client, $second['accessToken'], '/api/v1/wardrobe-app/auth/devices');
+        self::assertResponseIsSuccessful();
+        $devices = $this->json($client)['devices'];
+        self::assertCount(2, $devices);
+        $byId = array_column($devices, null, 'publicId');
+        self::assertFalse($byId[$first['device']['publicId']]['current']);
+        self::assertTrue($byId[$second['device']['publicId']]['current']);
+        self::assertSame('ipad', $byId[$second['device']['publicId']]['label']);
+        self::assertNotNull($byId[$second['device']['publicId']]['lastUsedAt']);
+
+        $client->jsonRequest('POST', '/api/v1/wardrobe-app/auth/login', [
+            'email' => $user->getEmail(), 'password' => UserFactory::PASSWORD,
+            'deviceId' => 'invalid-label-device', 'deviceLabel' => 'Anna iPhone',
+        ]);
+        self::assertResponseStatusCodeSame(400);
+        self::assertSame('invalid_device_label', $this->json($client)['error']);
+    }
+
+    public function testOwnerCanRevokeOtherAndCurrentDevice(): void
+    {
+        $client = static::createClient();
+        $user = UserFactory::withEmail(static::getContainer(), $this->email('device-revoke'));
+        $other = $this->login($client, $user, 'revoke-other-device');
+        $current = $this->login($client, $user, 'revoke-current-device');
+
+        $this->bearer($client, $current['accessToken'], '/api/v1/wardrobe-app/auth/devices/'.$other['device']['publicId'], 'DELETE');
+        self::assertResponseIsSuccessful();
+        $this->bearer($client, $other['accessToken'], '/api/v1/wardrobe-app/bootstrap');
+        self::assertResponseStatusCodeSame(401);
+        $client->jsonRequest('POST', '/api/v1/wardrobe-app/auth/refresh', ['refreshToken' => $other['refreshToken']]);
+        self::assertResponseStatusCodeSame(401);
+
+        $this->bearer($client, $current['accessToken'], '/api/v1/wardrobe-app/auth/devices/'.$current['device']['publicId'], 'DELETE');
+        self::assertResponseIsSuccessful();
+        $this->bearer($client, $current['accessToken'], '/api/v1/wardrobe-app/bootstrap');
+        self::assertResponseStatusCodeSame(401);
+    }
+
+    public function testDeviceRevokeDoesNotExposeOrModifyForeignSession(): void
+    {
+        $client = static::createClient();
+        $owner = UserFactory::withEmail(static::getContainer(), $this->email('device-owner'));
+        $attacker = UserFactory::withEmail(static::getContainer(), $this->email('device-attacker'));
+        $victim = $this->login($client, $owner, 'victim-device');
+        $foreign = $this->login($client, $attacker, 'attacker-device');
+
+        $this->bearer($client, $foreign['accessToken'], '/api/v1/wardrobe-app/auth/devices/'.$victim['device']['publicId'], 'DELETE');
+        self::assertResponseStatusCodeSame(404);
+        self::assertSame('device_not_found', $this->json($client)['error']);
+        $this->bearer($client, $victim['accessToken'], '/api/v1/wardrobe-app/bootstrap');
+        self::assertResponseIsSuccessful();
+    }
+
+    /** @return array<string, mixed> */
+    private function login(KernelBrowser $client, User $user, string $deviceId = 'iphone-test-device', string $password = UserFactory::PASSWORD, string $deviceLabel = 'other'): array
     {
         $client->jsonRequest('POST', '/api/v1/wardrobe-app/auth/login', [
-            'email' => $user->getEmail(), 'password' => $password, 'deviceId' => $deviceId,
+            'email' => $user->getEmail(), 'password' => $password, 'deviceId' => $deviceId, 'deviceLabel' => $deviceLabel,
         ]);
         self::assertResponseIsSuccessful();
 


### PR DESCRIPTION
## Что сделано
- opaque public device ID, allowlisted label и lastUsedAt для native sessions
- authenticated device list и owner-scoped revoke current/other device
- cleanup expired refresh receipts and revoked/expired sessions, scheduled daily
- migration and production runbook/docs

## Security
- database IDs and raw device IDs/tokens are never returned
- foreign and unknown public IDs have the same 404 response
- existing refresh rotation/replay detection and PWA cookie auth remain unchanged

## Tests
- focused: 13 tests, 90 assertions
- full PHPUnit: 770 tests, 2743 assertions, 9 deprecations
- lint:container OK (with required local AGENT_API_SECRET)
- Doctrine mapping OK
- Twig: 135 files OK