### PR TITLE
fix: gate deploy on wardrobe ingest health

### DIFF
--- a/.github/scripts/notify-deploy.sh
+++ b/.github/scripts/notify-deploy.sh
@@ -5,7 +5,7 @@
 #
 # Локальный прогон (без секретов и сети, только сборка текста):
 #   JOB_STATUS=success \
-#   OUTCOME_RSYNC=success OUTCOME_PRUNE=success OUTCOME_MIGRATE=success OUTCOME_SMOKE=success \
+#   OUTCOME_RSYNC=success OUTCOME_PRUNE=success OUTCOME_MIGRATE=success OUTCOME_SMOKE=success OUTCOME_INGEST_HEALTH=success \
 #   COMMIT_MESSAGE=$'fix(x): "quotes" <tag> & amp (#12)' \
 #   COMMIT_SHA=abcdef1234567890 COMMIT_AUTHOR=zyablik REPO=key-group/wearbase \
 #   BEFORE_SHA=0000000000000000000000000000000000000000 \
@@ -36,6 +36,7 @@ OUTCOME_RSYNC=${OUTCOME_RSYNC:-}
 OUTCOME_PRUNE=${OUTCOME_PRUNE:-}
 OUTCOME_MIGRATE=${OUTCOME_MIGRATE:-}
 OUTCOME_SMOKE=${OUTCOME_SMOKE:-}
+OUTCOME_INGEST_HEALTH=${OUTCOME_INGEST_HEALTH:-}
 COMMIT_MESSAGE=${COMMIT_MESSAGE:-}
 COMMIT_SHA=${COMMIT_SHA:-0000000000000000000000000000000000000000}
 COMMIT_AUTHOR=${COMMIT_AUTHOR:-unknown}
@@ -61,9 +62,9 @@ if [[ -n "$BEFORE_SHA" && ! "$BEFORE_SHA" =~ ^0+$ ]]; then
 fi
 
 find_failed_step() {
-  local names=(rsync prune migrate smoke)
-  local labels=("Rsync to prod" "Prune deleted code files" "Migrate + clear cache" "Smoke test")
-  local outcomes=("$OUTCOME_RSYNC" "$OUTCOME_PRUNE" "$OUTCOME_MIGRATE" "$OUTCOME_SMOKE")
+  local names=(rsync prune migrate smoke ingest_health)
+  local labels=("Rsync to prod" "Prune deleted code files" "Migrate + clear cache" "Smoke test" "Wardrobe ingest health gate")
+  local outcomes=("$OUTCOME_RSYNC" "$OUTCOME_PRUNE" "$OUTCOME_MIGRATE" "$OUTCOME_SMOKE" "$OUTCOME_INGEST_HEALTH")
   local i
   for i in "${!names[@]}"; do
     if [[ "${outcomes[$i]}" == "failure" ]]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,6 +190,21 @@ jobs:
           done
           exit $fail
 
+      - name: Wardrobe ingest health gate
+        id: ingest_health
+        # Read-only operational check: validates scheduler heartbeat, queue SLA and private
+        # storage after migrations. It does not claim drafts or call the vision model.
+        env:
+          H: ${{ secrets.DEPLOY_HOST }}
+          U: ${{ secrets.DEPLOY_USER }}
+          P: ${{ secrets.DEPLOY_PORT }}
+          D: ${{ secrets.DEPLOY_PATH }}
+        run: |
+          set -o pipefail
+          ssh -i ~/.ssh/deploy_key -p "${P}" -o UserKnownHostsFile=~/.ssh/known_hosts \
+            "${U}@${H}" "cd ${D} && APP_ENV=prod php bin/console app:wardrobe:ingest-health --check --json --no-debug" \
+            2>&1 | tee ingest-health.log
+
       - name: Notify Telegram
         # always(): шлём уведомление и при успехе, и при провале любого предыдущего
         # шага деплоя (rsync/prune/migrate/smoke). continue-on-error — сбой отправки
@@ -205,6 +220,7 @@ jobs:
           OUTCOME_PRUNE: ${{ steps.prune.outcome }}
           OUTCOME_MIGRATE: ${{ steps.migrate.outcome }}
           OUTCOME_SMOKE: ${{ steps.smoke.outcome }}
+          OUTCOME_INGEST_HEALTH: ${{ steps.ingest_health.outcome }}
           COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
           COMMIT_SHA: ${{ github.sha }}
           COMMIT_AUTHOR: ${{ github.actor }}

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -130,7 +130,7 @@ cp ops/com.wearbase.cron.plist ~/Library/LaunchAgents/ \
 | `app:wardrobe:ingest-drafts` | Фоновое vision-распознавание приватных batch-drafts с lease/retry. | ⏰ `*/2 * * * *` | ☁️ prod |
 | `app:wardrobe:cleanup-drafts` | Через 7 дней очищает photo/`ai_raw` accepted receipts; через 30 дней удаляет abandoned drafts. `--dry-run`. | ⏰ `17 3 * * *` | ☁️ prod |
 | `app:native-auth:cleanup` | Удаляет истёкшие refresh receipts, отозванные native device sessions и sessions без действующего refresh. | ⏰ `43 3 * * *` | ☁️ prod |
-| `app:wardrobe:ingest-health` | Очередь, oldest pending, expired lease, failed/retry, storage и последний scheduler run. `--json`, `--check`. Подробнее: [операционная проверка](wardrobe_ingest_operations.md). | 👆 smoke/monitoring | ☁️ prod |
+| `app:wardrobe:ingest-health` | Production gate: scheduler heartbeat 10 мин, oldest pending SLA 15 мин, expired lease, failed/retry и storage. `--json`, `--check`; AI не запускает. Подробнее: [операционная проверка](wardrobe_ingest_operations.md). | ⏰ `*/5 * * * *` + deploy | ☁️ prod |
 | `app:family:purchase-reminders` | Только in-app: раз в локальный день напоминает родителям о pending-запросах, а родителям и активированному ребёнку — о delivered-позициях без результата примерки. `--dry-run`, `--now=ISO-8601`; граница дня — Europe/Moscow, дедуп — состояние/объект/дата/получатель. | ⏰ `15 9 * * *` | ☁️ prod |
 | `app:notification:deliver-outbox` | Доставляет уже committed email, Telegram и Web Push с lease, retry/backoff и повторной проверкой настроек получателя. | ⏰ `* * * * *` | ☁️ prod |
 | `app:notifications:cleanup-web-push` | Удаляет отозванные Web Push subscriptions старше 30 дней. | ⏰ `41 3 * * *` | ☁️ prod |

--- a/docs/wardrobe_ingest_operations.md
+++ b/docs/wardrobe_ingest_operations.md
@@ -8,10 +8,16 @@ php bin/console app:wardrobe:ingest-health --json
 php bin/console app:wardrobe:ingest-health --check
 ```
 
-`--check` возвращает ненулевой код только при `critical`: каталог приватных загрузок отсутствует
-или недоступен для записи либо последний запуск scheduler завершился с ошибкой. Наличие retry,
-failed или истёкших lease отображается как `warning`: истёкший lease штатно забирается следующим
-worker-проходом, поэтому сам по себе не означает аварию.
+`--check` возвращает ненулевой код при `critical`. Критичны:
+
+- отсутствующая, отключённая или ошибочно привязанная не к `prod` строка ingest scheduler;
+- scheduler без единого запуска, последний неуспешный запуск или heartbeat старше 10 минут;
+- oldest pending старше 15 минут;
+- отсутствующий или недоступный для записи каталог приватных загрузок.
+
+Machine-readable `critical_reasons` содержит стабильные коды причины. Наличие retry, failed или
+истёкших lease до нарушения SLA отображается как `warning_reasons`: истёкший lease штатно забирается
+следующим worker-проходом, поэтому сам по себе не означает аварию.
 
 Команда показывает:
 
@@ -20,6 +26,9 @@ worker-проходом, поэтому сам по себе не означае
 - failed и pending, уже возвращённые на retry;
 - объём файлов по сохранённому `file_size`, доступность каталога для записи и свободное место;
 - состояние строки `scheduled_command`, время и exit code последнего запуска worker.
+
+Отдельная строка `scheduled_command` запускает health check каждые 5 минут. Её последний exit code
+и JSON доступны в админке scheduler. Проверка ничего не claim'ит и не вызывает vision/AI.
 
 ## Production smoke
 
@@ -33,6 +42,10 @@ APP_ENV=prod php bin/console app:wardrobe:ingest-health --json --no-debug
 Проверить, что `storage_writable=true`, `scheduler_configured=true`, последний exit code равен `0`,
 а возраст oldest pending уменьшается после очередного двухминутного запуска. При expired lease
 повторить команду после следующего тика: счётчик должен обнулиться или запись должна перейти в retry/failed.
+
+Deploy workflow выполняет тот же `--check --json` после миграций и HTTP smoke. Critical-состояние
+останавливает деплой и попадает отдельным шагом `Wardrobe ingest health gate` в уведомление, но сам
+gate не запускает ingest worker.
 
 ## Ограничение данных scheduler
 

--- a/migrations/Version20260824_wardrobe_ingest_health_gate.php
+++ b/migrations/Version20260824_wardrobe_ingest_health_gate.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260824_wardrobe_ingest_health_gate extends AbstractMigration
+{
+    public function getDescription(): string { return 'Schedule production wardrobe ingest health monitoring'; }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql("INSERT IGNORE INTO scheduled_command (environment, name, command, schedule, enabled) VALUES ('prod', 'Гардероб: здоровье распознавания', 'app:wardrobe:ingest-health --check --json --no-debug', '*/5 * * * *', 1)");
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql("DELETE FROM scheduled_command WHERE command = 'app:wardrobe:ingest-health --check --json --no-debug'");
+    }
+}

--- a/src/Command/Wardrobe/WardrobeIngestHealthCommand.php
+++ b/src/Command/Wardrobe/WardrobeIngestHealthCommand.php
@@ -39,6 +39,7 @@ final class WardrobeIngestHealthCommand extends Command
                 static fn (string $key, mixed $value): array => [$key, match (true) {
                     $value === null => 'unknown',
                     is_bool($value) => $value ? 'yes' : 'no',
+                    is_array($value) => $value === [] ? 'none' : implode(', ', $value),
                     default => (string) $value,
                 }],
                 array_keys($snapshot),

--- a/src/Service/Wardrobe/WardrobeIngestHealth.php
+++ b/src/Service/Wardrobe/WardrobeIngestHealth.php
@@ -9,13 +9,16 @@ use App\Repository\WardrobeItemDraftRepository;
 
 final class WardrobeIngestHealth
 {
+    public const SCHEDULER_SLA_SECONDS = 600;
+    public const PENDING_SLA_SECONDS = 900;
+
     public function __construct(
         private readonly WardrobeItemDraftRepository $drafts,
         private readonly ScheduledCommandRepository $scheduledCommands,
         private readonly string $storageDir,
     ) {}
 
-    /** @return array<string, bool|int|string|null> */
+    /** @return array<string, bool|int|string|array<int, string>|null> */
     public function snapshot(?\DateTimeImmutable $now = null): array
     {
         $now ??= new \DateTimeImmutable();
@@ -25,25 +28,46 @@ final class WardrobeIngestHealth
         $lastExitCode = $scheduler?->getLastExitCode();
         $storageExists = is_dir($this->storageDir);
         $storageWritable = $storageExists && is_writable($this->storageDir);
-
-        $status = 'ok';
-        if (!$storageWritable || ($lastExitCode !== null && $lastExitCode !== 0)) {
-            $status = 'critical';
-        } elseif ($drafts['expiredLeases'] > 0
-            || $drafts['retrying'] > 0
-            || $drafts['failed'] > 0
-            || $scheduler === null
-            || !$scheduler->isEnabled()
-            || $lastRun === null
-        ) {
-            $status = 'warning';
+        $oldestPendingAge = $drafts['oldestPendingAt'] === null ? null : max(0, $now->getTimestamp() - $drafts['oldestPendingAt']->getTimestamp());
+        $lastRunAge = $lastRun === null ? null : max(0, $now->getTimestamp() - $lastRun->getTimestamp());
+        $criticalReasons = [];
+        if (!$storageWritable) {
+            $criticalReasons[] = 'storage_not_writable';
         }
+        if ($scheduler === null) {
+            $criticalReasons[] = 'scheduler_missing';
+        } elseif (!$scheduler->isEnabled()) {
+            $criticalReasons[] = 'scheduler_disabled';
+        } elseif ($scheduler->getEnvironment() !== 'prod') {
+            $criticalReasons[] = 'scheduler_wrong_environment';
+        } elseif ($lastRun === null) {
+            $criticalReasons[] = 'scheduler_never_run';
+        } elseif ($lastRunAge > self::SCHEDULER_SLA_SECONDS) {
+            $criticalReasons[] = 'scheduler_stale';
+        }
+        if ($lastExitCode !== null && $lastExitCode !== 0) {
+            $criticalReasons[] = 'scheduler_last_run_failed';
+        }
+        if ($oldestPendingAge !== null && $oldestPendingAge > self::PENDING_SLA_SECONDS) {
+            $criticalReasons[] = 'oldest_pending_sla_exceeded';
+        }
+        $warningReasons = [];
+        foreach (['expiredLeases' => 'expired_leases', 'retrying' => 'retrying', 'failed' => 'failed'] as $metric => $reason) {
+            if ($drafts[$metric] > 0) {
+                $warningReasons[] = $reason;
+            }
+        }
+
+        $status = $criticalReasons !== [] ? 'critical' : ($warningReasons !== [] ? 'warning' : 'ok');
 
         return [
             'status' => $status,
+            'critical_reasons' => $criticalReasons,
+            'warning_reasons' => $warningReasons,
             'pending' => $drafts['pending'],
             'oldest_pending_at' => $drafts['oldestPendingAt']?->format(DATE_ATOM),
-            'oldest_pending_age_seconds' => $drafts['oldestPendingAt'] === null ? null : max(0, $now->getTimestamp() - $drafts['oldestPendingAt']->getTimestamp()),
+            'oldest_pending_age_seconds' => $oldestPendingAge,
+            'oldest_pending_sla_seconds' => self::PENDING_SLA_SECONDS,
             'expired_leases' => $drafts['expiredLeases'],
             'failed' => $drafts['failed'],
             'retrying' => $drafts['retrying'],
@@ -54,8 +78,10 @@ final class WardrobeIngestHealth
             'storage_free_bytes' => $storageExists ? $this->diskFreeSpace($this->storageDir) : null,
             'scheduler_configured' => $scheduler !== null,
             'scheduler_enabled' => $scheduler?->isEnabled(),
+            'scheduler_environment' => $scheduler?->getEnvironment(),
             'scheduler_last_run_at' => $lastRun?->format(DATE_ATOM),
-            'scheduler_last_run_age_seconds' => $lastRun === null ? null : max(0, $now->getTimestamp() - $lastRun->getTimestamp()),
+            'scheduler_last_run_age_seconds' => $lastRunAge,
+            'scheduler_sla_seconds' => self::SCHEDULER_SLA_SECONDS,
             'scheduler_last_exit_code' => $lastExitCode,
             'scheduler_last_success_at' => $lastExitCode === 0 ? $lastRun?->format(DATE_ATOM) : null,
             'scheduler_last_success_known' => $lastExitCode === 0,

--- a/tests/Command/WardrobeIngestHealthCommandTest.php
+++ b/tests/Command/WardrobeIngestHealthCommandTest.php
@@ -37,5 +37,25 @@ final class WardrobeIngestHealthCommandTest extends TestCase
         self::assertSame('critical', $payload['status']);
         self::assertFalse($payload['storage_writable']);
         self::assertFalse($payload['scheduler_configured']);
+        self::assertContains('scheduler_missing', $payload['critical_reasons']);
+        self::assertContains('storage_not_writable', $payload['critical_reasons']);
+    }
+
+    public function testHumanOutputRendersCriticalReasons(): void
+    {
+        $drafts = $this->createStub(WardrobeItemDraftRepository::class);
+        $drafts->method('operationalSnapshot')->willReturn([
+            'pending' => 0, 'oldestPendingAt' => null, 'expiredLeases' => 0,
+            'failed' => 0, 'retrying' => 0, 'storageBytes' => 0,
+        ]);
+        $scheduled = $this->createStub(ScheduledCommandRepository::class);
+        $tester = new CommandTester(new WardrobeIngestHealthCommand(
+            new WardrobeIngestHealth($drafts, $scheduled, '/missing/wardrobe-health-storage'),
+        ));
+
+        $tester->execute([]);
+
+        self::assertStringContainsString('scheduler_missing', $tester->getDisplay());
+        self::assertStringNotContainsString('Array', $tester->getDisplay());
     }
 }

--- a/tests/Service/Wardrobe/WardrobeIngestHealthTest.php
+++ b/tests/Service/Wardrobe/WardrobeIngestHealthTest.php
@@ -8,6 +8,7 @@ use App\Entity\ScheduledCommand;
 use App\Repository\ScheduledCommandRepository;
 use App\Repository\WardrobeItemDraftRepository;
 use App\Service\Wardrobe\WardrobeIngestHealth;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class WardrobeIngestHealthTest extends TestCase
@@ -38,7 +39,7 @@ final class WardrobeIngestHealthTest extends TestCase
             'storageBytes' => 4096,
         ]);
         $job = (new ScheduledCommand())
-            ->setName('ingest')->setCommand('app:wardrobe:ingest-drafts --no-debug')->setSchedule('*/2 * * * *')
+            ->setEnvironment('prod')->setName('ingest')->setCommand('app:wardrobe:ingest-drafts --no-debug')->setSchedule('*/2 * * * *')
             ->setLastRunAt(\DateTime::createFromImmutable($now->modify('-1 minute')))
             ->setLastExitCode(0);
         $scheduled = $this->createMock(ScheduledCommandRepository::class);
@@ -47,6 +48,7 @@ final class WardrobeIngestHealthTest extends TestCase
         $snapshot = (new WardrobeIngestHealth($drafts, $scheduled, $this->storageDir))->snapshot($now);
 
         self::assertSame('ok', $snapshot['status']);
+        self::assertSame([], $snapshot['critical_reasons']);
         self::assertSame(300, $snapshot['oldest_pending_age_seconds']);
         self::assertSame(4096, $snapshot['storage_usage_bytes']);
         self::assertTrue($snapshot['storage_writable']);
@@ -67,7 +69,7 @@ final class WardrobeIngestHealthTest extends TestCase
             'storageBytes' => 0,
         ]);
         $job = (new ScheduledCommand())
-            ->setName('ingest')->setCommand('app:wardrobe:ingest-drafts --no-debug')->setSchedule('*/2 * * * *')
+            ->setEnvironment('prod')->setName('ingest')->setCommand('app:wardrobe:ingest-drafts --no-debug')->setSchedule('*/2 * * * *')
             ->setLastRunAt(new \DateTime('2026-08-24T11:00:00+03:00'))
             ->setLastExitCode(1);
         $scheduled = $this->createMock(ScheduledCommandRepository::class);
@@ -80,5 +82,43 @@ final class WardrobeIngestHealthTest extends TestCase
         self::assertFalse($snapshot['storage_writable']);
         self::assertFalse($snapshot['scheduler_last_success_known']);
         self::assertNull($snapshot['scheduler_last_success_at']);
+        self::assertContains('scheduler_last_run_failed', $snapshot['critical_reasons']);
+    }
+
+    #[DataProvider('criticalSchedulerProvider')]
+    public function testSchedulerAndQueueSlaFailuresAreCritical(?ScheduledCommand $job, int $pendingAge, string $reason): void
+    {
+        $now = new \DateTimeImmutable('2026-08-24T12:00:00+03:00');
+        $drafts = $this->createMock(WardrobeItemDraftRepository::class);
+        $drafts->method('operationalSnapshot')->willReturn([
+            'pending' => 1,
+            'oldestPendingAt' => $now->modify(sprintf('-%d seconds', $pendingAge)),
+            'expiredLeases' => 0,
+            'failed' => 0,
+            'retrying' => 0,
+            'storageBytes' => 1,
+        ]);
+        $scheduled = $this->createMock(ScheduledCommandRepository::class);
+        $scheduled->method('findWardrobeIngestWorker')->willReturn($job);
+
+        $snapshot = (new WardrobeIngestHealth($drafts, $scheduled, $this->storageDir))->snapshot($now);
+
+        self::assertSame('critical', $snapshot['status']);
+        self::assertContains($reason, $snapshot['critical_reasons']);
+    }
+
+    /** @return iterable<string, array{?ScheduledCommand,int,string}> */
+    public static function criticalSchedulerProvider(): iterable
+    {
+        $healthy = static fn (): ScheduledCommand => (new ScheduledCommand())->setEnvironment('prod')
+            ->setName('ingest')->setCommand('app:wardrobe:ingest-drafts --no-debug')->setSchedule('*/2 * * * *')
+            ->setLastRunAt(new \DateTime('2026-08-24T11:59:00+03:00'))->setLastExitCode(0);
+
+        yield 'missing scheduler' => [null, 60, 'scheduler_missing'];
+        yield 'disabled scheduler' => [$healthy()->setEnabled(false), 60, 'scheduler_disabled'];
+        yield 'never run' => [$healthy()->setLastRunAt(null)->setLastExitCode(null), 60, 'scheduler_never_run'];
+        yield 'stale scheduler' => [$healthy()->setLastRunAt(new \DateTime('2026-08-24T11:49:00+03:00')), 60, 'scheduler_stale'];
+        yield 'wrong environment' => [$healthy()->setEnvironment('dev'), 60, 'scheduler_wrong_environment'];
+        yield 'oldest pending over SLA' => [$healthy(), WardrobeIngestHealth::PENDING_SLA_SECONDS + 1, 'oldest_pending_sla_exceeded'];
     }
 }


### PR DESCRIPTION
## Что изменено
- ingest scheduler missing/disabled/wrong-env/never-run/stale теперь critical
- heartbeat SLA: 10 минут; oldest pending SLA: 15 минут
- machine-readable critical_reasons/warning_reasons
- read-only deploy gate после миграций и HTTP smoke, без запуска ingest/vision
- health check запланирован каждые 5 минут; результат виден в scheduled_command
- deploy notification называет упавший health-gate шаг

## Проверки
- focused health: 11 tests, 42 assertions
- full PHPUnit: 780 tests, 2758 assertions, 9 deprecations
- lint:container: OK
- Doctrine mapping: OK
- workflow YAML + shell syntax: OK
- deploy notification dry-run: OK