### PR TITLE
feat(wardrobe): report privacy-safe activation funnel

### DIFF
--- a/_docs/wardrobe-activation-metrics.md
+++ b/_docs/wardrobe-activation-metrics.md
@@ -19,12 +19,26 @@ activation-события имеют другой lifecycle, retention и privac
 События начинают собираться после выкладки миграции; исторического backfill нет, поэтому время
 milestone не подменяется временем деплоя.
 
+Для эксплуатационного отчёта дополнительно записываются повторяемые события:
+
+- `batch_recognition_started|completed` — один раз на пачку;
+- `draft_accepted` — один раз на черновик, с `source=ai|manual_correction`, булевыми
+  `correction`/`autofillAccepted` и грубым `durationBucket`.
+
+UUID пачки и ID черновика не попадают в metadata: только их SHA-256 используется как технический
+`dedup_key`. Команда `php bin/console app:wardrobe:activation-report --days=30` отдаёт first-party
+JSON с дневными когортами, conversion/time-to-first-item/outfit/repeat, batch completion и долями
+исправлений/принятого autofill. Нулевой знаменатель всегда даёт rate `0`, исторического backfill нет.
+
 ## Privacy-контракт
 
 JSON metadata имеет закрытый контракт:
 
 - `actorKind`: только `self|family_manager`;
 - `entryPoint`: только `batch|manual|purchase|stylist|wear_review|outfit`.
+- `source`: только `ai|manual_correction`;
+- `durationBucket`: только `under_1m|1_5m|5_15m|over_15m`;
+- `correction`, `autofillAccepted`: boolean.
 
 Запрещены email, имя, возраст, ссылки магазинов, идентификаторы/названия/параметры вещей, фото,
 prompts и свободный текст. `profile_subject_id` — внутренний FK для построения воронки, удаляется

--- a/docs/tasktracker.md
+++ b/docs/tasktracker.md
@@ -2157,6 +2157,9 @@ SQL-инъекция там, где стоит `(int)`); зато один её 
   first outfit → repeat wear. Milestone уникален на профиль; metadata ограничена `actorKind`
   (`self|family_manager`) и low-cardinality `entryPoint`, без email, URL, фото, текста и параметров вещей.
   Исторический backfill намеренно не выполняется: когорта начинается с даты выкладки миграции.
+- [x] Добавить first-party activation report: дневные когорты и time-to-first milestones,
+  batch completion, correction/autofill acceptance. Повторяемые batch/draft события идемпотентны
+  по hashed dedup key; metadata — только low-cardinality allowlist без фото, URL и свободного текста.
 - [ ] Не начинать fine-tuning до достаточного подтверждённого корпуса, privacy-review и offline eval;
   выпускать LoRA только через A/B по повторным носкам и снижению неудачных покупок.
 

--- a/migrations/Version20260824_wardrobe_activation_funnel.php
+++ b/migrations/Version20260824_wardrobe_activation_funnel.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260824_wardrobe_activation_funnel extends AbstractMigration
+{
+    public function getDescription(): string { return 'Repeatable privacy-safe wardrobe activation events'; }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql("ALTER TABLE wardrobe_activation_event ADD dedup_key VARCHAR(64) NOT NULL DEFAULT ''");
+        $this->addSql('UPDATE wardrobe_activation_event SET dedup_key = event_type');
+        $this->addSql('DROP INDEX uniq_wardrobe_activation_milestone ON wardrobe_activation_event');
+        $this->addSql('CREATE UNIQUE INDEX uniq_wardrobe_activation_dedup ON wardrobe_activation_event (profile_subject_id, event_type, dedup_key)');
+        $this->addSql("ALTER TABLE wardrobe_activation_event ALTER dedup_key DROP DEFAULT");
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX uniq_wardrobe_activation_dedup ON wardrobe_activation_event');
+        $this->addSql('ALTER TABLE wardrobe_activation_event DROP dedup_key');
+        $this->addSql('CREATE UNIQUE INDEX uniq_wardrobe_activation_milestone ON wardrobe_activation_event (profile_subject_id, event_type)');
+    }
+}

--- a/src/Command/Wardrobe/ActivationReportCommand.php
+++ b/src/Command/Wardrobe/ActivationReportCommand.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Command\Wardrobe;
+
+use App\Repository\WardrobeActivationEventRepository;
+use App\Service\Wardrobe\WardrobeActivationReport;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand(name: 'app:wardrobe:activation-report', description: 'Privacy-safe product activation funnel for wardrobe')]
+final class ActivationReportCommand extends Command
+{
+    public function __construct(
+        private readonly WardrobeActivationEventRepository $events,
+        private readonly WardrobeActivationReport $report,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->addOption('days', null, InputOption::VALUE_REQUIRED, 'Reporting window in days', '30');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $days = filter_var($input->getOption('days'), FILTER_VALIDATE_INT, ['options' => ['min_range' => 1, 'max_range' => 366]]);
+        if ($days === false) {
+            $output->writeln('<error>--days must be between 1 and 366</error>');
+            return Command::INVALID;
+        }
+        $to = new \DateTimeImmutable('tomorrow midnight');
+        $result = $this->report->build($this->events->findReportRows($to->modify(sprintf('-%d days', $days)), $to));
+        $output->writeln(json_encode($result, JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE));
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Command/Wardrobe/IngestWardrobeDraftsCommand.php
+++ b/src/Command/Wardrobe/IngestWardrobeDraftsCommand.php
@@ -7,6 +7,7 @@ namespace App\Command\Wardrobe;
 use App\Entity\WardrobeItemDraft;
 use App\Repository\WardrobeItemDraftRepository;
 use App\Service\Wardrobe\WardrobeAiService;
+use App\Service\Wardrobe\WardrobeActivationService;
 use App\Service\WardrobeAiMeter;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
@@ -42,6 +43,7 @@ class IngestWardrobeDraftsCommand extends Command
         private readonly WardrobeAiMeter $meter,
         #[Autowire('%kernel.project_dir%')]
         private readonly string $projectDir,
+        private readonly ?WardrobeActivationService $activation = null,
     ) {
         parent::__construct();
     }
@@ -76,8 +78,19 @@ class IngestWardrobeDraftsCommand extends Command
 
         $recognized = 0;
         $failed = 0;
+        $batches = [];
 
         foreach ($drafts as $draft) {
+            $subject = $draft->getProfileSubject();
+            $actor = $draft->getActor();
+            $batchId = $draft->getBatchId();
+            if ($subject !== null && $actor !== null && $batchId !== null) {
+                $batchKey = $subject->getId().':'.$batchId;
+                if (!isset($batches[$batchKey])) {
+                    $batches[$batchKey] = [$actor, $subject, $batchId];
+                    $this->activation?->batchRecognitionStarted($actor, $subject, $batchId);
+                }
+            }
             $draftId = $draft->getId();
             if ($draftId === null) {
                 continue;
@@ -139,6 +152,13 @@ class IngestWardrobeDraftsCommand extends Command
                     $failed++;
                     $io->text(sprintf('#%d: ошибка — %s', $draftId, $error));
                 }
+            }
+        }
+
+        foreach ($batches as [$actor, $subject, $batchId]) {
+            $counts = $this->draftRepo->countsByBatch($subject, $batchId);
+            if ($counts['total'] === $counts['recognized'] + $counts['failed']) {
+                $this->activation?->batchRecognitionCompleted($actor, $subject, $batchId);
             }
         }
 

--- a/src/Entity/WardrobeActivationEvent.php
+++ b/src/Entity/WardrobeActivationEvent.php
@@ -9,13 +9,16 @@ use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity(repositoryClass: WardrobeActivationEventRepository::class)]
 #[ORM\Table(name: 'wardrobe_activation_event')]
-#[ORM\UniqueConstraint(name: 'uniq_wardrobe_activation_milestone', columns: ['profile_subject_id', 'event_type'])]
+#[ORM\UniqueConstraint(name: 'uniq_wardrobe_activation_dedup', columns: ['profile_subject_id', 'event_type', 'dedup_key'])]
 class WardrobeActivationEvent
 {
     public const ONBOARDING_STARTED = 'onboarding_started';
     public const FIRST_ITEM_ADDED = 'first_item_added';
     public const FIRST_OUTFIT_CREATED = 'first_outfit_created';
     public const REPEAT_WEAR_RECORDED = 'repeat_wear_recorded';
+    public const BATCH_RECOGNITION_STARTED = 'batch_recognition_started';
+    public const BATCH_RECOGNITION_COMPLETED = 'batch_recognition_completed';
+    public const DRAFT_ACCEPTED = 'draft_accepted';
 
     #[ORM\Id]
     #[ORM\GeneratedValue]
@@ -29,18 +32,22 @@ class WardrobeActivationEvent
     #[ORM\Column(length: 32)]
     private string $eventType;
 
-    /** @var array{actorKind:string,entryPoint:string} */
+    #[ORM\Column(length: 64)]
+    private string $dedupKey;
+
+    /** @var array<string, bool|string> */
     #[ORM\Column(type: 'json')]
     private array $metadata;
 
     #[ORM\Column]
     private \DateTimeImmutable $occurredAt;
 
-    /** @param array{actorKind:string,entryPoint:string} $metadata */
-    public function __construct(User $profileSubject, string $eventType, array $metadata, ?\DateTimeImmutable $occurredAt = null)
+    /** @param array<string, bool|string> $metadata */
+    public function __construct(User $profileSubject, string $eventType, string $dedupKey, array $metadata, ?\DateTimeImmutable $occurredAt = null)
     {
         $this->profileSubject = $profileSubject;
         $this->eventType = $eventType;
+        $this->dedupKey = $dedupKey;
         $this->metadata = $metadata;
         $this->occurredAt = $occurredAt ?? new \DateTimeImmutable();
     }
@@ -48,7 +55,8 @@ class WardrobeActivationEvent
     public function getId(): ?int { return $this->id; }
     public function getProfileSubject(): User { return $this->profileSubject; }
     public function getEventType(): string { return $this->eventType; }
-    /** @return array{actorKind:string,entryPoint:string} */
+    public function getDedupKey(): string { return $this->dedupKey; }
+    /** @return array<string, bool|string> */
     public function getMetadata(): array { return $this->metadata; }
     public function getOccurredAt(): \DateTimeImmutable { return $this->occurredAt; }
 }

--- a/src/Repository/WardrobeActivationEventRepository.php
+++ b/src/Repository/WardrobeActivationEventRepository.php
@@ -15,13 +15,14 @@ class WardrobeActivationEventRepository extends ServiceEntityRepository
 {
     public function __construct(ManagerRegistry $registry) { parent::__construct($registry, WardrobeActivationEvent::class); }
 
-    /** @param array{actorKind:string,entryPoint:string} $metadata */
-    public function recordOnce(User $subject, string $eventType, array $metadata): bool
+    /** @param array<string, bool|string> $metadata */
+    public function recordOnce(User $subject, string $eventType, string $dedupKey, array $metadata): bool
     {
         try {
             $this->getEntityManager()->getConnection()->insert('wardrobe_activation_event', [
                 'profile_subject_id' => $subject->getId(),
                 'event_type' => $eventType,
+                'dedup_key' => $dedupKey,
                 'metadata' => json_encode($metadata, JSON_THROW_ON_ERROR),
                 'occurred_at' => (new \DateTimeImmutable())->format('Y-m-d H:i:s'),
             ]);
@@ -30,5 +31,21 @@ class WardrobeActivationEventRepository extends ServiceEntityRepository
         }
 
         return true;
+    }
+
+    /** @return list<array{profileSubjectId:int,eventType:string,metadata:array<string,bool|string>,occurredAt:string}> */
+    public function findReportRows(\DateTimeImmutable $from, \DateTimeImmutable $to): array
+    {
+        $rows = $this->getEntityManager()->getConnection()->fetchAllAssociative(
+            'SELECT profile_subject_id, event_type, metadata, occurred_at FROM wardrobe_activation_event WHERE occurred_at >= :from AND occurred_at < :to ORDER BY occurred_at ASC',
+            ['from' => $from->format('Y-m-d H:i:s'), 'to' => $to->format('Y-m-d H:i:s')],
+        );
+
+        return array_map(static fn (array $row): array => [
+            'profileSubjectId' => (int) $row['profile_subject_id'],
+            'eventType' => (string) $row['event_type'],
+            'metadata' => json_decode((string) $row['metadata'], true, flags: JSON_THROW_ON_ERROR),
+            'occurredAt' => (string) $row['occurred_at'],
+        ], $rows);
     }
 }

--- a/src/Service/Wardrobe/WardrobeActivationReport.php
+++ b/src/Service/Wardrobe/WardrobeActivationReport.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Wardrobe;
+
+use App\Entity\WardrobeActivationEvent;
+
+final class WardrobeActivationReport
+{
+    /**
+     * @param list<array{profileSubjectId:int,eventType:string,metadata:array<string,bool|string>,occurredAt:string}> $rows
+     * @return array<string, mixed>
+     */
+    public function build(array $rows): array
+    {
+        $starts = [];
+        $milestones = [
+            WardrobeActivationEvent::FIRST_ITEM_ADDED => [],
+            WardrobeActivationEvent::FIRST_OUTFIT_CREATED => [],
+            WardrobeActivationEvent::REPEAT_WEAR_RECORDED => [],
+        ];
+        $counts = array_count_values(array_column($rows, 'eventType'));
+        $drafts = array_values(array_filter($rows, static fn (array $row): bool => $row['eventType'] === WardrobeActivationEvent::DRAFT_ACCEPTED));
+
+        foreach ($rows as $row) {
+            $at = new \DateTimeImmutable($row['occurredAt']);
+            $subject = $row['profileSubjectId'];
+            if ($row['eventType'] === WardrobeActivationEvent::ONBOARDING_STARTED) {
+                $starts[$subject] ??= $at;
+            } elseif (isset($milestones[$row['eventType']])) {
+                $milestones[$row['eventType']][$subject] ??= $at;
+            }
+        }
+
+        $cohorts = [];
+        foreach ($starts as $subject => $startedAt) {
+            $day = $startedAt->format('Y-m-d');
+            $cohorts[$day] ??= ['started' => 0, 'firstItem' => 0, 'firstOutfit' => 0, 'repeatWear' => 0];
+            $cohorts[$day]['started']++;
+            foreach ([WardrobeActivationEvent::FIRST_ITEM_ADDED => 'firstItem', WardrobeActivationEvent::FIRST_OUTFIT_CREATED => 'firstOutfit', WardrobeActivationEvent::REPEAT_WEAR_RECORDED => 'repeatWear'] as $event => $key) {
+                if (isset($milestones[$event][$subject])) {
+                    $cohorts[$day][$key]++;
+                }
+            }
+        }
+        ksort($cohorts);
+
+        return [
+            'subjectsStarted' => count($starts),
+            'milestones' => [
+                'firstItem' => $this->milestone($starts, $milestones[WardrobeActivationEvent::FIRST_ITEM_ADDED]),
+                'firstOutfit' => $this->milestone($starts, $milestones[WardrobeActivationEvent::FIRST_OUTFIT_CREATED]),
+                'repeatWear' => $this->milestone($starts, $milestones[WardrobeActivationEvent::REPEAT_WEAR_RECORDED]),
+            ],
+            'batch' => $this->ratio(
+                $counts[WardrobeActivationEvent::BATCH_RECOGNITION_COMPLETED] ?? 0,
+                $counts[WardrobeActivationEvent::BATCH_RECOGNITION_STARTED] ?? 0,
+            ),
+            'manualInput' => [
+                'accepted' => count($drafts),
+                'correction' => $this->flagRatio($drafts, 'correction'),
+                'autofillAccepted' => $this->flagRatio($drafts, 'autofillAccepted'),
+                'source' => array_count_values(array_map(static fn (array $row): string => (string) ($row['metadata']['source'] ?? 'unknown'), $drafts)),
+                'durationBuckets' => array_count_values(array_map(static fn (array $row): string => (string) ($row['metadata']['durationBucket'] ?? 'unknown'), $drafts)),
+            ],
+            'cohorts' => $cohorts,
+        ];
+    }
+
+    /** @param array<int,\DateTimeImmutable> $starts @param array<int,\DateTimeImmutable> $ends */
+    private function milestone(array $starts, array $ends): array
+    {
+        $seconds = [];
+        foreach ($starts as $subject => $start) {
+            if (isset($ends[$subject]) && $ends[$subject] >= $start) {
+                $seconds[] = $ends[$subject]->getTimestamp() - $start->getTimestamp();
+            }
+        }
+
+        return $this->ratio(count($seconds), count($starts)) + [
+            'averageSeconds' => $seconds === [] ? null : (int) round(array_sum($seconds) / count($seconds)),
+        ];
+    }
+
+    /** @return array{count:int,total:int,rate:float} */
+    private function ratio(int $count, int $total): array
+    {
+        return ['count' => $count, 'total' => $total, 'rate' => $total === 0 ? 0.0 : round($count / $total, 4)];
+    }
+
+    /** @param list<array{metadata:array<string,bool|string>}> $rows */
+    private function flagRatio(array $rows, string $key): array
+    {
+        return $this->ratio(count(array_filter($rows, static fn (array $row): bool => ($row['metadata'][$key] ?? false) === true)), count($rows));
+    }
+}

--- a/src/Service/Wardrobe/WardrobeActivationService.php
+++ b/src/Service/Wardrobe/WardrobeActivationService.php
@@ -39,16 +39,43 @@ final class WardrobeActivationService
         $this->record($actor, $subject, WardrobeActivationEvent::REPEAT_WEAR_RECORDED, $entryPoint);
     }
 
-    private function record(User $actor, User $subject, string $eventType, string $entryPoint): void
+    public function batchRecognitionStarted(User $actor, User $subject, string $batchId): void
+    {
+        $this->record($actor, $subject, WardrobeActivationEvent::BATCH_RECOGNITION_STARTED, 'batch', $this->hash($batchId));
+    }
+
+    public function batchRecognitionCompleted(User $actor, User $subject, string $batchId): void
+    {
+        $this->record($actor, $subject, WardrobeActivationEvent::BATCH_RECOGNITION_COMPLETED, 'batch', $this->hash($batchId));
+    }
+
+    public function draftAccepted(User $actor, User $subject, int $draftId, string $source, string $durationBucket, bool $correction, bool $autofillAccepted): void
+    {
+        if (!in_array($source, ['ai', 'manual_correction'], true)
+            || !in_array($durationBucket, ['under_1m', '1_5m', '5_15m', 'over_15m'], true)
+        ) {
+            throw new \InvalidArgumentException('Unknown draft activation metadata');
+        }
+        $this->record($actor, $subject, WardrobeActivationEvent::DRAFT_ACCEPTED, 'batch', $this->hash((string) $draftId), [
+            'source' => $source,
+            'durationBucket' => $durationBucket,
+            'correction' => $correction,
+            'autofillAccepted' => $autofillAccepted,
+        ]);
+    }
+
+    /** @param array<string, bool|string> $extra */
+    private function record(User $actor, User $subject, string $eventType, string $entryPoint, ?string $dedupKey = null, array $extra = []): void
     {
         if (!in_array($entryPoint, self::ENTRY_POINTS, true)) {
             throw new \InvalidArgumentException('Unknown activation entry point');
         }
 
         try {
-            $this->events->recordOnce($subject, $eventType, [
+            $this->events->recordOnce($subject, $eventType, $dedupKey ?? $eventType, [
                 'actorKind' => $actor->getId() === $subject->getId() ? 'self' : 'family_manager',
                 'entryPoint' => $entryPoint,
+                ...$extra,
             ]);
         } catch (Exception $exception) {
             // Product telemetry must never roll back a successful wardrobe action.
@@ -57,5 +84,10 @@ final class WardrobeActivationService
                 'exception' => $exception,
             ]);
         }
+    }
+
+    private function hash(string $value): string
+    {
+        return hash('sha256', $value);
     }
 }

--- a/src/Service/Wardrobe/WardrobeDraftPromotionService.php
+++ b/src/Service/Wardrobe/WardrobeDraftPromotionService.php
@@ -44,13 +44,24 @@ final class WardrobeDraftPromotionService
         }
 
         $this->activation?->firstItemAdded($actor, $result['item']->getUser(), 'batch');
+        if (!$result['idempotent']) {
+            $this->activation?->draftAccepted(
+                $actor,
+                $result['item']->getUser(),
+                $draftId,
+                $result['correction'] ? 'manual_correction' : 'ai',
+                $result['durationBucket'],
+                $result['correction'],
+                $result['autofillAccepted'],
+            );
+        }
 
-        return $result;
+        return ['item' => $result['item'], 'idempotent' => $result['idempotent']];
     }
 
     /**
      * @param array{name?:mixed,category?:mixed,size?:mixed,notes?:mixed} $overrides
-     * @return array{item:WardrobeItem,idempotent:bool}
+     * @return array{item:WardrobeItem,idempotent:bool,correction:bool,durationBucket:string,autofillAccepted:bool}
      */
     private function attempt(?int $actorId, int $draftId, array $overrides): array
     {
@@ -76,7 +87,7 @@ final class WardrobeDraftPromotionService
                     throw new \DomainException('Принятый черновик повреждён');
                 }
                 $connection->commit();
-                return ['item' => $item, 'idempotent' => true];
+                return ['item' => $item, 'idempotent' => true, 'correction' => false, 'durationBucket' => 'under_1m', 'autofillAccepted' => false];
             }
             if (!in_array($draft->getStatus(), [WardrobeItemDraft::STATUS_RECOGNIZED, WardrobeItemDraft::STATUS_FAILED], true)) {
                 throw new \DomainException('Черновик ещё не готов к подтверждению');
@@ -89,6 +100,12 @@ final class WardrobeDraftPromotionService
             if ($category === null || $name === null) {
                 throw new \DomainException('Заполните категорию и название');
             }
+            $correction = $draft->getStatus() === WardrobeItemDraft::STATUS_FAILED
+                || $category !== $draft->getCategory()
+                || $name !== $draft->getName()
+                || $size !== $draft->getSize()
+                || $notes !== $draft->getNotes();
+            $durationBucket = $this->durationBucket($draft->getCreatedAt());
 
             // Сериализует выдачу itemNo для одного владельца между web workers.
             $em->lock($subject, LockMode::PESSIMISTIC_WRITE);
@@ -126,7 +143,13 @@ final class WardrobeDraftPromotionService
             $em->flush();
             $connection->commit();
 
-            return ['item' => $item, 'idempotent' => false];
+            return [
+                'item' => $item,
+                'idempotent' => false,
+                'correction' => $correction,
+                'durationBucket' => $durationBucket,
+                'autofillAccepted' => !$correction,
+            ];
         } catch (\Throwable $exception) {
             if ($connection->isTransactionActive()) {
                 $connection->rollBack();
@@ -142,6 +165,18 @@ final class WardrobeDraftPromotionService
             }
             throw $exception;
         }
+    }
+
+    private function durationBucket(\DateTimeInterface $startedAt): string
+    {
+        $seconds = max(0, time() - $startedAt->getTimestamp());
+
+        return match (true) {
+            $seconds < 60 => 'under_1m',
+            $seconds < 300 => '1_5m',
+            $seconds < 900 => '5_15m',
+            default => 'over_15m',
+        };
     }
 
     /** @param array<string, mixed> $overrides */

--- a/tests/Command/IngestWardrobeDraftsActivationTest.php
+++ b/tests/Command/IngestWardrobeDraftsActivationTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Command;
+
+use App\Command\Wardrobe\IngestWardrobeDraftsCommand;
+use App\Entity\User;
+use App\Entity\WardrobeItemDraft;
+use App\Repository\WardrobeItemDraftRepository;
+use App\Repository\WardrobeActivationEventRepository;
+use App\Entity\WardrobeActivationEvent;
+use App\Service\Wardrobe\WardrobeActivationService;
+use App\Service\Wardrobe\WardrobeAiService;
+use App\Service\WardrobeAiMeter;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+use Vich\UploaderBundle\Storage\StorageInterface;
+
+final class IngestWardrobeDraftsActivationTest extends TestCase
+{
+    public function testRecordsBatchStartAndCompletionOnceAroundClaimedWork(): void
+    {
+        $actor = $this->user(1);
+        $subject = $this->user(2);
+        $draft = (new WardrobeItemDraft())->setActor($actor)->setProfileSubject($subject)->setBatchId('test-batch');
+        (new \ReflectionProperty(WardrobeItemDraft::class, 'id'))->setValue($draft, 10);
+
+        $drafts = $this->createMock(WardrobeItemDraftRepository::class);
+        $drafts->method('claimPending')->willReturn([$draft]);
+        $drafts->expects(self::once())->method('finishClaim')->willReturn(true);
+        $drafts->method('countsByBatch')->willReturn(['total' => 1, 'pending' => 0, 'recognized' => 0, 'failed' => 1]);
+        $events = $this->createMock(WardrobeActivationEventRepository::class);
+        $recorded = [];
+        $events->expects(self::exactly(2))->method('recordOnce')->willReturnCallback(
+            static function (User $eventSubject, string $event, string $key, array $metadata) use (&$recorded, $subject): bool {
+                self::assertSame($subject, $eventSubject);
+                self::assertSame(hash('sha256', 'test-batch'), $key);
+                self::assertSame(['actorKind' => 'family_manager', 'entryPoint' => 'batch'], $metadata);
+                $recorded[] = $event;
+                return true;
+            },
+        );
+        $activation = new WardrobeActivationService($events);
+        $storage = $this->createStub(StorageInterface::class);
+        $storage->method('resolvePath')->willReturn(null);
+        $meter = $this->createStub(WardrobeAiMeter::class);
+        $meter->method('allowed')->willReturn(true);
+        $projectDir = sys_get_temp_dir().'/wardrobe_activation_'.bin2hex(random_bytes(4));
+        mkdir($projectDir.'/var', 0777, true);
+
+        try {
+            $command = new IngestWardrobeDraftsCommand(
+                $drafts,
+                $this->createStub(WardrobeAiService::class),
+                $storage,
+                $meter,
+                $projectDir,
+                $activation,
+            );
+            self::assertSame(Command::SUCCESS, (new CommandTester($command))->execute([]));
+            self::assertSame([
+                WardrobeActivationEvent::BATCH_RECOGNITION_STARTED,
+                WardrobeActivationEvent::BATCH_RECOGNITION_COMPLETED,
+            ], $recorded);
+        } finally {
+            @unlink($projectDir.'/var/wardrobe_ingest_drafts.lock');
+            @rmdir($projectDir.'/var');
+            @rmdir($projectDir);
+        }
+    }
+
+    private function user(int $id): User
+    {
+        $user = new User();
+        (new \ReflectionProperty(User::class, 'id'))->setValue($user, $id);
+        return $user;
+    }
+}

--- a/tests/Command/WardrobeActivationReportCommandTest.php
+++ b/tests/Command/WardrobeActivationReportCommandTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Command;
+
+use App\Command\Wardrobe\ActivationReportCommand;
+use App\Repository\WardrobeActivationEventRepository;
+use App\Service\Wardrobe\WardrobeActivationReport;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+final class WardrobeActivationReportCommandTest extends TestCase
+{
+    public function testOutputsMachineReadableAggregateWithoutRawEvents(): void
+    {
+        $events = $this->createMock(WardrobeActivationEventRepository::class);
+        $events->expects(self::once())->method('findReportRows')->willReturn([]);
+        $tester = new CommandTester(new ActivationReportCommand($events, new WardrobeActivationReport()));
+
+        self::assertSame(Command::SUCCESS, $tester->execute(['--days' => '7']));
+        $payload = json_decode($tester->getDisplay(), true, flags: JSON_THROW_ON_ERROR);
+        self::assertSame(0, $payload['subjectsStarted']);
+        self::assertArrayNotHasKey('events', $payload);
+    }
+
+    public function testRejectsUnboundedWindow(): void
+    {
+        $tester = new CommandTester(new ActivationReportCommand(
+            $this->createStub(WardrobeActivationEventRepository::class),
+            new WardrobeActivationReport(),
+        ));
+
+        self::assertSame(Command::INVALID, $tester->execute(['--days' => '367']));
+    }
+}

--- a/tests/Controller/WardrobeIngestControllerTest.php
+++ b/tests/Controller/WardrobeIngestControllerTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Controller;
 
 use App\Entity\User;
 use App\Entity\Wardrobe;
+use App\Entity\WardrobeActivationEvent;
 use App\Entity\WardrobeItem;
 use App\Entity\WardrobeItemDraft;
 use App\Entity\WardrobeOnboarding;
@@ -297,6 +298,13 @@ class WardrobeIngestControllerTest extends AuthenticatedWebTestCase
         $this->assertSame($data['itemId'], $retry['itemId']);
         $this->assertTrue($retry['idempotent']);
         $this->assertSame($itemCountBefore + 1, $em->getRepository(WardrobeItem::class)->count([]));
+        $acceptedEvents = $em->getRepository(WardrobeActivationEvent::class)->findBy([
+            'profileSubject' => $user,
+            'eventType' => WardrobeActivationEvent::DRAFT_ACCEPTED,
+        ]);
+        $this->assertCount(1, $acceptedEvents);
+        $this->assertSame('manual_correction', $acceptedEvents[0]->getMetadata()['source']);
+        $this->assertTrue($acceptedEvents[0]->getMetadata()['correction']);
     }
 
     /**

--- a/tests/Repository/WardrobeActivationEventRepositoryTest.php
+++ b/tests/Repository/WardrobeActivationEventRepositoryTest.php
@@ -18,7 +18,7 @@ final class WardrobeActivationEventRepositoryTest extends TestCase
     public function testRecordOnceIsIdempotent(): void
     {
         $connection = DriverManager::getConnection(['driver' => 'pdo_sqlite', 'memory' => true]);
-        $connection->executeStatement('CREATE TABLE wardrobe_activation_event (id INTEGER PRIMARY KEY AUTOINCREMENT, profile_subject_id INTEGER NOT NULL, event_type VARCHAR(32) NOT NULL, metadata JSON NOT NULL, occurred_at DATETIME NOT NULL, UNIQUE (profile_subject_id, event_type))');
+        $connection->executeStatement('CREATE TABLE wardrobe_activation_event (id INTEGER PRIMARY KEY AUTOINCREMENT, profile_subject_id INTEGER NOT NULL, event_type VARCHAR(32) NOT NULL, dedup_key VARCHAR(64) NOT NULL, metadata JSON NOT NULL, occurred_at DATETIME NOT NULL, UNIQUE (profile_subject_id, event_type, dedup_key))');
         $em = $this->createStub(EntityManagerInterface::class);
         $em->method('getClassMetadata')->willReturn(new ClassMetadata(WardrobeActivationEvent::class));
         $em->method('getConnection')->willReturn($connection);
@@ -29,8 +29,26 @@ final class WardrobeActivationEventRepositoryTest extends TestCase
         (new \ReflectionProperty(User::class, 'id'))->setValue($subject, 42);
         $metadata = ['actorKind' => 'self', 'entryPoint' => 'manual'];
 
-        self::assertTrue($repository->recordOnce($subject, WardrobeActivationEvent::FIRST_ITEM_ADDED, $metadata));
-        self::assertFalse($repository->recordOnce($subject, WardrobeActivationEvent::FIRST_ITEM_ADDED, $metadata));
+        self::assertTrue($repository->recordOnce($subject, WardrobeActivationEvent::FIRST_ITEM_ADDED, 'first_item_added', $metadata));
+        self::assertFalse($repository->recordOnce($subject, WardrobeActivationEvent::FIRST_ITEM_ADDED, 'first_item_added', $metadata));
         self::assertSame(1, (int) $connection->fetchOne('SELECT COUNT(*) FROM wardrobe_activation_event'));
+    }
+
+    public function testDifferentOpaqueDedupKeysAreRecorded(): void
+    {
+        $connection = DriverManager::getConnection(['driver' => 'pdo_sqlite', 'memory' => true]);
+        $connection->executeStatement('CREATE TABLE wardrobe_activation_event (id INTEGER PRIMARY KEY AUTOINCREMENT, profile_subject_id INTEGER NOT NULL, event_type VARCHAR(32) NOT NULL, dedup_key VARCHAR(64) NOT NULL, metadata JSON NOT NULL, occurred_at DATETIME NOT NULL, UNIQUE (profile_subject_id, event_type, dedup_key))');
+        $em = $this->createStub(EntityManagerInterface::class);
+        $em->method('getClassMetadata')->willReturn(new ClassMetadata(WardrobeActivationEvent::class));
+        $em->method('getConnection')->willReturn($connection);
+        $registry = $this->createStub(ManagerRegistry::class);
+        $registry->method('getManagerForClass')->willReturn($em);
+        $repository = new WardrobeActivationEventRepository($registry);
+        $subject = new User();
+        (new \ReflectionProperty(User::class, 'id'))->setValue($subject, 42);
+
+        self::assertTrue($repository->recordOnce($subject, WardrobeActivationEvent::DRAFT_ACCEPTED, hash('sha256', '1'), ['actorKind' => 'self', 'entryPoint' => 'batch']));
+        self::assertTrue($repository->recordOnce($subject, WardrobeActivationEvent::DRAFT_ACCEPTED, hash('sha256', '2'), ['actorKind' => 'self', 'entryPoint' => 'batch']));
+        self::assertSame(2, (int) $connection->fetchOne('SELECT COUNT(*) FROM wardrobe_activation_event'));
     }
 }

--- a/tests/Service/Wardrobe/WardrobeActivationReportTest.php
+++ b/tests/Service/Wardrobe/WardrobeActivationReportTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Service\Wardrobe;
+
+use App\Entity\WardrobeActivationEvent;
+use App\Service\Wardrobe\WardrobeActivationReport;
+use PHPUnit\Framework\TestCase;
+
+final class WardrobeActivationReportTest extends TestCase
+{
+    public function testBuildsFunnelCohortsAndManualInputEvidence(): void
+    {
+        $rows = [
+            $this->row(1, WardrobeActivationEvent::ONBOARDING_STARTED, '2026-08-01 10:00:00'),
+            $this->row(2, WardrobeActivationEvent::ONBOARDING_STARTED, '2026-08-01 11:00:00'),
+            $this->row(1, WardrobeActivationEvent::FIRST_ITEM_ADDED, '2026-08-01 10:02:00'),
+            $this->row(1, WardrobeActivationEvent::FIRST_OUTFIT_CREATED, '2026-08-01 10:12:00'),
+            $this->row(1, WardrobeActivationEvent::REPEAT_WEAR_RECORDED, '2026-08-02 10:00:00'),
+            $this->row(1, WardrobeActivationEvent::BATCH_RECOGNITION_STARTED, '2026-08-01 10:00:10'),
+            $this->row(1, WardrobeActivationEvent::BATCH_RECOGNITION_COMPLETED, '2026-08-01 10:01:00'),
+            $this->row(1, WardrobeActivationEvent::DRAFT_ACCEPTED, '2026-08-01 10:02:00', ['source' => 'ai', 'durationBucket' => '1_5m', 'correction' => false, 'autofillAccepted' => true]),
+            $this->row(2, WardrobeActivationEvent::DRAFT_ACCEPTED, '2026-08-01 11:04:00', ['source' => 'manual_correction', 'durationBucket' => '1_5m', 'correction' => true, 'autofillAccepted' => false]),
+        ];
+
+        $report = (new WardrobeActivationReport())->build($rows);
+
+        self::assertSame(2, $report['subjectsStarted']);
+        self::assertSame(['count' => 1, 'total' => 2, 'rate' => 0.5, 'averageSeconds' => 120], $report['milestones']['firstItem']);
+        self::assertSame(1.0, $report['batch']['rate']);
+        self::assertSame(0.5, $report['manualInput']['correction']['rate']);
+        self::assertSame(0.5, $report['manualInput']['autofillAccepted']['rate']);
+        self::assertSame(['started' => 2, 'firstItem' => 1, 'firstOutfit' => 1, 'repeatWear' => 1], $report['cohorts']['2026-08-01']);
+    }
+
+    /** @param array<string,bool|string> $metadata */
+    private function row(int $subject, string $event, string $at, array $metadata = []): array
+    {
+        return ['profileSubjectId' => $subject, 'eventType' => $event, 'metadata' => $metadata, 'occurredAt' => $at];
+    }
+}

--- a/tests/Service/Wardrobe/WardrobeActivationServiceTest.php
+++ b/tests/Service/Wardrobe/WardrobeActivationServiceTest.php
@@ -21,6 +21,7 @@ final class WardrobeActivationServiceTest extends TestCase
         $events->expects(self::once())->method('recordOnce')->with(
             $subject,
             WardrobeActivationEvent::FIRST_ITEM_ADDED,
+            WardrobeActivationEvent::FIRST_ITEM_ADDED,
             ['actorKind' => 'family_manager', 'entryPoint' => 'batch'],
         );
 
@@ -44,6 +45,7 @@ final class WardrobeActivationServiceTest extends TestCase
         $events->expects(self::once())->method('recordOnce')->with(
             $subject,
             $eventType,
+            $eventType,
             ['actorKind' => 'self', 'entryPoint' => $entryPoint],
         );
         $service = new WardrobeActivationService($events);
@@ -53,6 +55,34 @@ final class WardrobeActivationServiceTest extends TestCase
         } else {
             $service->{$method}($subject, $subject);
         }
+    }
+
+    public function testDraftMetadataIsBoundedAndDedupKeyIsHashed(): void
+    {
+        $subject = $this->userWithId(10);
+        $events = $this->createMock(WardrobeActivationEventRepository::class);
+        $events->expects(self::once())->method('recordOnce')->with(
+            $subject,
+            WardrobeActivationEvent::DRAFT_ACCEPTED,
+            hash('sha256', '42'),
+            [
+                'actorKind' => 'self',
+                'entryPoint' => 'batch',
+                'source' => 'manual_correction',
+                'durationBucket' => '1_5m',
+                'correction' => true,
+                'autofillAccepted' => false,
+            ],
+        );
+
+        (new WardrobeActivationService($events))->draftAccepted($subject, $subject, 42, 'manual_correction', '1_5m', true, false);
+    }
+
+    public function testRejectsFreeTextDraftMetadata(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        (new WardrobeActivationService($this->createStub(WardrobeActivationEventRepository::class)))
+            ->draftAccepted($this->userWithId(10), $this->userWithId(10), 42, 'email@example.test', '1_5m', true, false);
     }
 
     /** @return iterable<string, array{string,string,string}> */


### PR DESCRIPTION
## Summary
- add idempotent batch recognition and draft acceptance activation events using hashed dedup keys and a strict low-cardinality metadata contract
- add a first-party CLI funnel/cohort report for time-to-first milestones, batch completion, correction rate, and autofill acceptance
- document the privacy contract and product-metrics completion in the task tracker

## Verification
- `php -d memory_limit=512M ./vendor/bin/phpunit tests/Service/Wardrobe tests/Controller/WardrobeIngestControllerTest.php tests/Command/WardrobeActivationReportCommandTest.php tests/Repository/WardrobeActivationEventRepositoryTest.php` — 58 tests, 272 assertions
- focused collector/report suite — 28 tests, 146 assertions
- `php bin/console lint:container`
- `php bin/console doctrine:schema:validate --skip-sync`
- full PHPUnit: 779 tests / 2771 assertions; 2 unrelated existing/environment failures (`FixNullParentCommandTest` legacy default, EasyAdmin importmap asset missing locally)