### PR TITLE
feat/news pipeline

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -59,6 +59,11 @@ parameters:
     env(SITE_BASE_URL): 'https://wearbase.ru'
     app.site_base_url: '%env(SITE_BASE_URL)%'
 
+    # News pipeline (парсер → рерайт → модерация): ollama и предохранитель автопубликации
+    env(OLLAMA_URL): 'http://127.0.0.1:11434'
+    env(OLLAMA_MODEL): 'qwen3.5:27b'
+    env(NEWS_AUTO_PUBLISH): '0'
+
 services:
     # default configuration for services in *this* file
     _defaults:
@@ -87,7 +92,16 @@ services:
             $privateKey: '%env(WEB_PUSH_PRIVATE_KEY)%'
             $subject: '%env(WEB_PUSH_SUBJECT)%'
 
-    # add more service definitions when explicit configuration is needed
+    # News pipeline: ollama HTTP-клиент (URL/модель — env, см. параметры выше)
+    App\Service\News\OllamaClient:
+        arguments:
+            $ollamaUrl: '%env(OLLAMA_URL)%'
+            $model: '%env(OLLAMA_MODEL)%'
+
+    App\Command\NewsProcessCommand:
+        arguments:
+            $autoPublish: '%env(bool:NEWS_AUTO_PUBLISH)%'
+
     # please note that last definitions always *replace* previous ones
 
     App\Service\LlmService:

--- a/migrations/Version20260825_news_pipeline.php
+++ b/migrations/Version20260825_news_pipeline.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Подсистема «парсер → рерайт → модерация»: справочник источников
+ * и очередь новостей. Источники MVP сидируются сразу (_docs/news-sources.md).
+ */
+final class Version20260825_news_pipeline extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'News pipeline: news_source catalog (seeded) and news_item queue';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            CREATE TABLE news_source (
+                id INT AUTO_INCREMENT NOT NULL,
+                name VARCHAR(255) NOT NULL,
+                feed_url VARCHAR(512) NOT NULL,
+                tos_mode VARCHAR(16) DEFAULT 'facts_only' NOT NULL,
+                active TINYINT(1) DEFAULT 1 NOT NULL,
+                rubric_hint VARCHAR(64) DEFAULT NULL,
+                created_at DATETIME DEFAULT CURRENT_TIMESTAMP NOT NULL,
+                updated_at DATETIME DEFAULT CURRENT_TIMESTAMP NOT NULL,
+                UNIQUE INDEX UNIQ_news_source_name (name),
+                UNIQUE INDEX UNIQ_news_source_feed_url (feed_url),
+                PRIMARY KEY(id)
+            ) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB
+            SQL);
+        $this->addSql(<<<'SQL'
+            CREATE TABLE news_item (
+                id INT AUTO_INCREMENT NOT NULL,
+                source_id INT NOT NULL,
+                guid_hash CHAR(64) NOT NULL,
+                url VARCHAR(512) NOT NULL,
+                slug VARCHAR(255) DEFAULT NULL,
+                title VARCHAR(512) NOT NULL,
+                source_name VARCHAR(255) NOT NULL,
+                source_url VARCHAR(512) NOT NULL,
+                published_at DATETIME DEFAULT NULL,
+                raw_fetched_text LONGTEXT DEFAULT NULL,
+                rewritten_title VARCHAR(512) DEFAULT NULL,
+                rewritten_body LONGTEXT DEFAULT NULL,
+                ready_at DATETIME DEFAULT NULL,
+                rubric VARCHAR(16) DEFAULT NULL,
+                shingle_score DOUBLE PRECISION DEFAULT NULL,
+                status VARCHAR(16) DEFAULT 'discovered' NOT NULL,
+                status_timestamps LONGTEXT DEFAULT NULL COMMENT '(DC2Type:json)',
+                reject_reason VARCHAR(255) DEFAULT NULL,
+                created_at DATETIME DEFAULT CURRENT_TIMESTAMP NOT NULL,
+                updated_at DATETIME DEFAULT CURRENT_TIMESTAMP NOT NULL,
+                INDEX IDX_news_item_status (status),
+                INDEX IDX_news_item_slug (slug),
+                UNIQUE INDEX UNIQ_news_item_slug (slug),
+                UNIQUE INDEX UNIQ_news_item_source_guid (source_id, guid_hash),
+                PRIMARY KEY(id),
+                CONSTRAINT FK_news_item_source FOREIGN KEY (source_id) REFERENCES news_source (id) ON DELETE CASCADE
+            ) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB
+            SQL);
+
+        // Сид источников MVP: 4 facts_only активных + 2 forbidden выключенных
+        // (_docs/news-sources.md §1, _docs/news-sources-tos.md §3).
+        // Список синхронизирован с App\Service\News\NewsSourcesCatalog (сид-команда).
+        $this->addSql("INSERT INTO news_source (name, feed_url, tos_mode, active, rubric_hint, created_at, updated_at) VALUES\n" . implode(",\n", [
+            "('Parents.ru', 'https://www.parents.ru/rss-feeds/rss.xml', 'facts_only', 1, 'дети', NOW(), NOW())",
+            "('Woman.ru', 'https://www.woman.ru/rss/', 'facts_only', 1, 'мода', NOW(), NOW())",
+            "('The-Day', 'https://the-day.ru/rss-feeds/rss.xml', 'facts_only', 1, NULL, NOW(), NOW())",
+            "('Sobaka.ru', 'https://www.sobaka.ru/rss/news.xml', 'facts_only', 1, NULL, NOW(), NOW())",
+            "('Buro 24/7', 'https://www.buro247.ru/xml/rss.xml', 'forbidden', 0, NULL, NOW(), NOW())",
+            "('РБК Стиль', 'https://style.rbc.ru/', 'forbidden', 0, NULL, NOW(), NOW())",
+        ]));
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP TABLE news_item');
+        $this->addSql('DROP TABLE news_source');
+    }
+}

--- a/src/Command/NewsFetchCommand.php
+++ b/src/Command/NewsFetchCommand.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Command;
+
+use App\Entity\NewsItem;
+use App\Entity\NewsSource;
+use App\Enum\NewsItemStatus;
+use App\Enum\TosMode;
+use App\Repository\NewsSourceRepository;
+use App\Service\News\HostPoliteness;
+use App\Service\News\RssParser;
+use App\Service\News\UrlNormalizer;
+use Doctrine\ORM\EntityManagerInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * Шаг «парсер»: обходим активные источники, читаем RSS, дедуп по
+ * (source, sha256 нормализованного guid/URL), новые — status=discovered.
+ *
+ * Политики (_docs/news-sources.md / -tos.md):
+ *  - tos_mode=forbidden пропускается жёстко, даже если active=1;
+ *  - вежливость: ≤1 запроса/сек на хост;
+ *  - фид служит только детектором новинок — текст догружает process.
+ */
+#[AsCommand(name: 'app:news:fetch', description: 'Читает RSS активных источников, новые статьи кладёт как discovered')]
+final class NewsFetchCommand extends Command
+{
+    private const REQUEST_TIMEOUT = 20.0;
+
+    public function __construct(
+        private readonly EntityManagerInterface $em,
+        private readonly HttpClientInterface $httpClient,
+        private readonly RssParser $rssParser,
+        private readonly UrlNormalizer $urlNormalizer,
+        private readonly HostPoliteness $politeness,
+        private readonly NewsSourceRepository $sources,
+        private readonly LoggerInterface $logger,
+    ) {
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $inserted = 0;
+        $skippedTos = 0;
+
+        foreach ($this->sources->findBy(['active' => true]) as $source) {
+            if ($source->getTosMode() === TosMode::Forbidden) {
+                // Жёсткий skip: правообладатель запретил сбор/переработку.
+                ++$skippedTos;
+                $output->writeln(sprintf('[skip-tos] %s (forbidden)', $source->getName()));
+                continue;
+            }
+
+            try {
+                $inserted += $this->fetchSource($source);
+            } catch (\Throwable $e) {
+                // Один упавший источник не останавливает обход остальных.
+                $this->logger->warning('news:fetch source failed', [
+                    'source' => $source->getName(),
+                    'error' => $e->getMessage(),
+                ]);
+                $output->writeln(sprintf('<comment>[fail] %s: %s</comment>', $source->getName(), $e->getMessage()));
+            }
+        }
+
+        $output->writeln(sprintf('Fetched: %d new item(s), %d skipped by ToS', $inserted, $skippedTos));
+
+        return Command::SUCCESS;
+    }
+
+    private function fetchSource(NewsSource $source): int
+    {
+        $host = (string) parse_url($source->getFeedUrl(), PHP_URL_HOST);
+        $this->politeness->guard($host);
+
+        $response = $this->httpClient->request('GET', $source->getFeedUrl(), ['timeout' => self::REQUEST_TIMEOUT]);
+        if ($response->getStatusCode() >= 300) {
+            throw new \RuntimeException(sprintf('HTTP %d от фида', $response->getStatusCode()));
+        }
+        $items = $this->rssParser->parse($response->getContent());
+
+        $inserted = 0;
+        foreach ($items as $item) {
+            $guidHash = $this->urlNormalizer->guidHash($item['guid'], $item['link']);
+            if ($this->em->getRepository(NewsItem::class)->findBySourceAndGuidHash($source->getId(), $guidHash) !== null) {
+                continue; // дедуп: уже видели этот guid/URL у источника
+            }
+
+            $news = (new NewsItem())
+                ->setSource($source)
+                ->setGuidHash($guidHash)
+                ->setUrl($item['link'])
+                ->setTitle(mb_substr($item['title'], 0, 512))
+                ->setSourceName($source->getName())
+                ->setSourceUrl($item['link'])
+                ->setStatus(NewsItemStatus::Discovered);
+            if ($item['pubDate'] !== null) {
+                $news->setPublishedAt(\DateTime::createFromImmutable($item['pubDate']));
+            }
+
+            $this->em->persist($news);
+            ++$inserted;
+        }
+        $this->em->flush();
+
+        return $inserted;
+    }
+}

--- a/src/Command/NewsProcessCommand.php
+++ b/src/Command/NewsProcessCommand.php
@@ -1,0 +1,221 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Command;
+
+use App\Entity\NewsItem;
+use App\Enum\NewsItemStatus;
+use App\Repository\NewsItemRepository;
+use App\Service\News\ArticleTextExtractor;
+use App\Service\News\HostPoliteness;
+use App\Service\News\NewsLlmUnavailableException;
+use App\Service\News\NewsRewriter;
+use App\Service\News\NewsSlugger;
+use App\Service\News\ShingleGate;
+use Doctrine\ORM\EntityManagerInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * Шаги «рерайт → гейты → готово» для discovered/fetched:
+ *  1) догрузка HTML статьи + извлечение текста (DOM-фильтр script/style/nav…);
+ *  2) LLM-рерайт «заметка на основе фактов» + рубрикатор (та же LLM);
+ *  3) шингл-гейт: доля 5-грамм с исходником ≤10%, иначе rejected;
+ *  4) кап готовых к публикации ≤8/день (по ready_at с начала суток);
+ *  5) NEWS_AUTO_PUBLISH=1 — сразу published, иначе ждёт модерации.
+ *
+ * LLM недоступна → item остаётся в fetched, ошибка в логе, конвейер живёт.
+ */
+#[AsCommand(name: 'app:news:process', description: 'Догружает тексты, делает рерайт через ollama, гонит через шингл-гейт и дневной кап')]
+final class NewsProcessCommand extends Command
+{
+    private const READY_CAP_PER_DAY = 8;
+    private const REQUEST_TIMEOUT = 20.0;
+
+    public function __construct(
+        private readonly EntityManagerInterface $em,
+        private readonly HttpClientInterface $httpClient,
+        private readonly NewsItemRepository $items,
+        private readonly NewsRewriter $rewriter,
+        private readonly ArticleTextExtractor $extractor,
+        private readonly ShingleGate $shingleGate,
+        private readonly NewsSlugger $slugger,
+        private readonly HostPoliteness $politeness,
+        private readonly LoggerInterface $logger,
+        private readonly bool $autoPublish = false,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->addOption('limit', null, InputOption::VALUE_REQUIRED, 'Сколько item взять за запуск', '20');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $limit = max(1, (int) $input->getOption('limit'));
+        $todayStart = (new \DateTimeImmutable('today'));
+
+        // Кап считается по уже готовым (ready/published) за сегодня.
+        $remaining = self::READY_CAP_PER_DAY - $this->items->countReadySince($todayStart);
+        $output->writeln(sprintf('Daily ready cap: %d used, %d remaining', self::READY_CAP_PER_DAY - $remaining, max(0, $remaining)));
+
+        // Сначала добиваем переписанные, но не вошедшие в кап прошлых запусков.
+        if ($remaining > 0) {
+            $pending = $this->items->findBy(['status' => NewsItemStatus::Rewritten], ['id' => 'ASC'], $remaining);
+            foreach ($pending as $item) {
+                --$remaining;
+                $this->promoteToReady($item);
+                ++$ready;
+            }
+            if ($pending !== []) {
+                $this->em->flush();
+            }
+        }
+
+        $processed = 0;
+        $rejected = 0;
+        $ready = 0;
+        foreach ($this->items->findProcessable($limit) as $item) {
+            try {
+                if ($item->getRawFetchedText() === null) {
+                    if (!$this->fetchArticle($item)) {
+                        ++$rejected;
+                        continue; // fetch_failed
+                    }
+                }
+
+                if (!$this->rewriteItem($item)) {
+                    continue; // LLM недоступна или мусорный ответ — останется в fetched
+                }
+            } catch (\Throwable $e) {
+                $this->logger->error('news:process item failed', [
+                    'id' => $item->getId(),
+                    'error' => $e->getMessage(),
+                ]);
+                $output->writeln(sprintf('<comment>[fail] #%d: %s</comment>', $item->getId(), $e->getMessage()));
+                continue;
+            }
+
+            ++$processed;
+
+            // Готов к публикации — но только в пределах дневного капа.
+            if ($remaining > 0) {
+                --$remaining;
+                $this->promoteToReady($item);
+                ++$ready;
+            }
+            $this->em->flush();
+        }
+
+        if ($this->autoPublish) {
+            $published = $this->publishReady();
+            $output->writeln(sprintf('Auto-published: %d', $published));
+        }
+
+        $output->writeln(sprintf('Processed: %d rewritten, %d ready, %d rejected (fetch)', $processed, $ready, $rejected));
+
+        return Command::SUCCESS;
+    }
+
+    /** Догрузка и извлечение текста. false → rejected (fetch_failed). */
+    private function fetchArticle(NewsItem $item): bool
+    {
+        $host = (string) parse_url($item->getUrl(), PHP_URL_HOST);
+        $this->politeness->guard($host);
+
+        try {
+            $response = $this->httpClient->request('GET', $item->getUrl(), ['timeout' => self::REQUEST_TIMEOUT]);
+            if ($response->getStatusCode() >= 300) {
+                throw new \RuntimeException(sprintf('HTTP %d', $response->getStatusCode()));
+            }
+            $html = $response->getContent();
+        } catch (\Throwable $e) {
+            $this->reject($item, 'fetch_failed: ' . mb_substr($e->getMessage(), 0, 200));
+            return false;
+        }
+
+        $text = $this->extractor->extract($html);
+        if ($text === null) {
+            $this->reject($item, 'fetch_failed: текст не извлечён');
+            return false;
+        }
+
+        $item->setRawFetchedText($text)->setStatus(NewsItemStatus::Fetched);
+
+        return true;
+    }
+
+    /**
+     * Рерайт + шингл-гейт. false = остаётся fetched (LLM недоступна / мусор)
+     * либо rejected (жанр из чёрного списка, шинглы).
+     */
+    private function rewriteItem(NewsItem $item): bool
+    {
+        if ($this->rewriter->isForbiddenGenre($item->getTitle())) {
+            $this->reject($item, 'forbidden_genre');
+            return false;
+        }
+
+        try {
+            $result = $this->rewriter->rewrite($item->getSourceName(), $item->getRawFetchedText() ?? '', $item->getSource()->getRubricHint());
+        } catch (NewsLlmUnavailableException | \RuntimeException $e) {
+            // Не падаем и не реджектим: transient-сбой, попробуем на следующем запуске.
+            $this->logger->warning('news:process rewrite skipped', ['id' => $item->getId(), 'error' => $e->getMessage()]);
+            return false;
+        }
+
+        $score = $this->shingleGate->overlap($item->getRawFetchedText() ?? '', $result['body']);
+        $item->setShingleScore(round($score, 4));
+        if (!$this->shingleGate->passes($score)) {
+            $this->reject($item, sprintf('shingle_gate: %.1f%% > 10%%', $score * 100));
+            return false;
+        }
+
+        $item->setRewrittenTitle(mb_substr($result['title'], 0, 512))
+            ->setRewrittenBody($result['body'])
+            ->setRubric($result['rubric'])
+            ->setStatus(NewsItemStatus::Rewritten);
+
+        return true;
+    }
+
+    /** Ready: слаг из транслита заголовка (уникальный), отметка ready_at. */
+    private function promoteToReady(NewsItem $item): void
+    {
+        $base = $this->slugger->slugify($item->getRewrittenTitle() ?? $item->getTitle());
+        $slug = $base;
+        $i = 2;
+        while ($this->items->findOneBy(['slug' => $slug]) !== null) {
+            $slug = $base . '-' . $i++;
+        }
+        $item->setSlug($slug)->setStatus(NewsItemStatus::Ready);
+    }
+
+    /** NEWS_AUTO_PUBLISH=1: всё готовое уходит в published. */
+    private function publishReady(): int
+    {
+        $readyItems = $this->items->findBy(['status' => NewsItemStatus::Ready]);
+        foreach ($readyItems as $item) {
+            $item->setStatus(NewsItemStatus::Published);
+        }
+        if ($readyItems !== []) {
+            $this->em->flush();
+        }
+
+        return count($readyItems);
+    }
+
+    private function reject(NewsItem $item, string $reason): void
+    {
+        $item->setStatus(NewsItemStatus::Rejected)->setRejectReason($reason);
+        $this->em->flush();
+    }
+}

--- a/src/Command/NewsSourcesSeedCommand.php
+++ b/src/Command/NewsSourcesSeedCommand.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Command;
+
+use App\Entity\NewsSource;
+use App\Repository\NewsSourceRepository;
+use App\Service\News\NewsSourcesCatalog;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Сид справочника источников MVP (идемпотентный upsert по name).
+ * Те же 6 записей, что кладёт миграция Version20260825_news_pipeline:
+ * 4 facts_only активных + 2 forbidden выключенных (_docs/news-sources-tos.md §3).
+ */
+#[AsCommand(name: 'app:news:sources:seed', description: 'Сид справочника источников новостей (4 facts_only + 2 forbidden)')]
+final class NewsSourcesSeedCommand extends Command
+{
+    public function __construct(
+        private readonly EntityManagerInterface $em,
+        private readonly NewsSourceRepository $sources,
+    ) {
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $created = 0;
+        $updated = 0;
+
+        foreach (NewsSourcesCatalog::all() as $spec) {
+            $source = $this->sources->findOneBy(['name' => $spec['name']]);
+            if ($source === null) {
+                $source = new NewsSource();
+                $source->setName($spec['name']);
+                ++$created;
+            } else {
+                ++$updated;
+            }
+
+            $source->setFeedUrl($spec['feedUrl'])
+                ->setTosMode($spec['tosMode'])
+                ->setActive($spec['active'])
+                ->setRubricHint($spec['rubricHint']);
+            $this->em->persist($source);
+        }
+
+        $this->em->flush();
+        $output->writeln(sprintf('news_source: %d created, %d updated', $created, $updated));
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Controller/Admin/DashboardController.php
+++ b/src/Controller/Admin/DashboardController.php
@@ -7,6 +7,7 @@ use App\Entity\AdvisorIdea;
 use App\Entity\AdvisorRun;
 use App\Entity\AiUsageLog;
 use App\Entity\Article;
+use App\Entity\NewsItem;
 use App\Entity\Author;
 use App\Entity\Brand;
 use App\Entity\BrandAudience;
@@ -84,6 +85,8 @@ class DashboardController extends AbstractDashboardController
         yield MenuItem::linkToRoute('Клики по брендам', 'fas fa-arrow-up-right-from-square', 'admin_clicks');
         yield MenuItem::linkToRoute('Динамика Яндекс', 'fas fa-chart-line', 'admin_yandex_dynamics');
         yield MenuItem::linkToCrud('Статьи блога', 'fas fa-newspaper', Article::class);
+        yield MenuItem::linkToCrud('Новости (модерация)', 'fas fa-rss', NewsItem::class)
+            ->setController(NewsItemCrudController::class);
         yield MenuItem::linkToCrud('Авторы', 'fas fa-user-pen', Author::class);
         yield MenuItem::linkToCrud('SEO города (хабы)', 'fas fa-city', CityHub::class);
 

--- a/src/Controller/Admin/NewsItemCrudController.php
+++ b/src/Controller/Admin/NewsItemCrudController.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller\Admin;
+
+use App\Entity\NewsItem;
+use App\Enum\NewsItemStatus;
+use App\Repository\NewsItemRepository;
+use App\Service\News\NewsSlugger;
+use Doctrine\ORM\EntityManagerInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Actions;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Filters;
+use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
+use EasyCorp\Bundle\EasyAdminBundle\Field\ChoiceField;
+use EasyCorp\Bundle\EasyAdminBundle\Field\DateTimeField;
+use EasyCorp\Bundle\EasyAdminBundle\Field\IdField;
+use EasyCorp\Bundle\EasyAdminBundle\Field\NumberField;
+use EasyCorp\Bundle\EasyAdminBundle\Field\TextareaField;
+use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
+use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGenerator;
+use Nevinny\AdminCoreBundle\Controller\Admin\DefaultCrudController;
+use Nevinny\AdminCoreBundle\Service\SectionPathGenerator;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * Модерация новостей (первые 2 недели — только ручная публикация,
+ * NEWS_AUTO_PUBLISH=0 по умолчанию). Publish/Reject — кастомные crud-действия.
+ */
+final class NewsItemCrudController extends DefaultCrudController
+{
+    public function __construct(
+        RequestStack $requestStack,
+        EntityManagerInterface $entityManager,
+        AdminUrlGenerator $adminUrlGenerator,
+        SectionPathGenerator $pathGenerator,
+        private readonly NewsItemRepository $items,
+        private readonly NewsSlugger $slugger,
+    ) {
+        parent::__construct($requestStack, $entityManager, $adminUrlGenerator, $pathGenerator);
+    }
+
+    public static function getEntityFqcn(): string
+    {
+        return NewsItem::class;
+    }
+
+    public function configureCrud(Crud $crud): Crud
+    {
+        return parent::configureCrud($crud)
+            ->setDefaultSort(['id' => 'DESC'])
+            ->setEntityLabelInSingular('Новость')
+            ->setEntityLabelInPlural('Новости (модерация)')
+            ->showEntityActionsInlined();
+    }
+
+    public function configureActions(Actions $actions): Actions
+    {
+        $publish = Action::new('publish', 'Опубликовать', 'fa fa-check')
+            ->linkToCrudAction('publishAction')
+            ->addCssClass('btn btn-success btn-sm')
+            ->displayIf(static fn (NewsItem $item) => $item->getStatus() === NewsItemStatus::Ready);
+        $reject = Action::new('reject', 'Отклонить', 'fa fa-ban')
+            ->linkToCrudAction('rejectAction')
+            ->addCssClass('btn btn-danger btn-sm')
+            ->displayIf(static fn (NewsItem $item) => in_array($item->getStatus(), [NewsItemStatus::Ready, NewsItemStatus::Rewritten], true));
+
+        return parent::configureActions($actions)
+            ->add(Action::INDEX, $publish)
+            ->add(Action::INDEX, $reject)
+            ->add(Action::DETAIL, $publish)
+            ->add(Action::DETAIL, $reject);
+    }
+
+    /** Ручная публикация админом разрешена всегда (независимо от NEWS_AUTO_PUBLISH). */
+    public function publishAction(AdminContext $context): RedirectResponse
+    {
+        /** @var NewsItem|null $item */
+        $item = $context->getEntity()->getInstance();
+        if ($item !== null && $item->getStatus() === NewsItemStatus::Ready) {
+            if ($item->getSlug() === null) {
+                $this->assignUniqueSlug($item);
+            }
+            $item->setStatus(NewsItemStatus::Published);
+            $this->entityManager->flush();
+        }
+
+        return $this->redirectBack($context);
+    }
+
+    public function rejectAction(AdminContext $context): RedirectResponse
+    {
+        /** @var NewsItem|null $item */
+        $item = $context->getEntity()->getInstance();
+        if ($item !== null && in_array($item->getStatus(), [NewsItemStatus::Ready, NewsItemStatus::Rewritten], true)) {
+            $item->setStatus(NewsItemStatus::Rejected)->setRejectReason('manual_moderation');
+            $this->entityManager->flush();
+        }
+
+        return $this->redirectBack($context);
+    }
+
+    private function redirectBack(AdminContext $context): RedirectResponse
+    {
+        $url = $context->getReferrer()
+            ?? $this->getAdminUrlGenerator()->setController(self::class)->setAction(Action::INDEX)->generateUrl();
+
+        return new RedirectResponse($url);
+    }
+
+    private function assignUniqueSlug(NewsItem $item): void
+    {
+        $base = $this->slugger->slugify($item->getRewrittenTitle() ?? $item->getTitle());
+        $slug = $base;
+        $i = 2;
+        while ($this->items->findOneBy(['slug' => $slug]) !== null) {
+            $slug = $base . '-' . $i++;
+        }
+        $item->setSlug($slug);
+    }
+
+    public function configureFields(string $pageName): iterable
+    {
+        yield IdField::new('id')->onlyOnIndex();
+        yield TextField::new('sourceName', 'Издание')->onlyOnIndex();
+        yield TextField::new('title', 'Заголовок из фида')
+            ->hideOnIndex()
+            ->setFormTypeOption('disabled', true);
+        yield TextField::new('rewrittenTitle', 'Наш заголовок');
+        yield TextareaField::new('rewrittenBody', 'Наша заметка')
+            ->hideOnIndex()
+            ->setNumOfRows(18);
+        yield TextField::new('slug', 'Слаг')
+            ->hideWhenCreating()
+            ->setHelp('Публичный URL /news/&lt;слаг&gt;; проставляется при ready/publish');
+        yield ChoiceField::new('status', 'Статус')
+            ->setChoices(array_combine(
+                array_map(static fn ($c) => $c->value, NewsItemStatus::cases()),
+                array_map(static fn ($c) => $c->value, NewsItemStatus::cases()),
+            ))
+            ->setFormTypeOption('disabled', true);
+        yield TextField::new('rubric', 'Рубрика')->onlyOnIndex();
+        yield NumberField::new('shingleScore', 'Шинглы')
+            ->hideOnIndex()
+            ->setNumOfDecimals(4)
+            ->setHelp('Доля совпадений 5-грамм с исходником; гейт ≤0.10');
+        yield TextField::new('rejectReason', 'Причина отказа')->hideOnIndex()->setFormTypeOption('disabled', true);
+        yield DateTimeField::new('readyAt', 'Готово')->hideOnIndex()->setFormTypeOption('disabled', true);
+        yield DateTimeField::new('createdAt', 'Создано')->onlyOnIndex()->setFormTypeOption('disabled', true);
+    }
+
+    public function configureFilters(Filters $filters): Filters
+    {
+        return $filters
+            ->add('status')
+            ->add('rubric')
+            ->add('sourceName');
+    }
+}

--- a/src/Controller/NewsController.php
+++ b/src/Controller/NewsController.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use App\Repository\NewsItemRepository;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+/**
+ * Публичная лента новостей /news и страница /news/{slug}.
+ * Индексируемые (без noindex), self-canonical; блок «По материалам …»
+ * с постоянным dofollow обязателен (_docs/news-sources-tos.md §2.2).
+ */
+final class NewsController extends AbstractController
+{
+    private const PER_PAGE = 12;
+
+    public function __construct(private readonly NewsItemRepository $items)
+    {
+    }
+
+    #[Route('/news', name: 'news_index')]
+    public function index(Request $request): Response
+    {
+        $page = max(1, $request->query->getInt('page', 1));
+
+        $total = $this->items->countPublished();
+        $totalPages = max(1, (int) ceil($total / self::PER_PAGE));
+        $page = min($page, $totalPages);
+
+        return $this->render('tailwind/news/index.html.twig', [
+            'items' => $this->items->findPublished(self::PER_PAGE, ($page - 1) * self::PER_PAGE),
+            'page' => $page,
+            'totalPages' => $totalPages,
+        ]);
+    }
+
+    #[Route('/news/{slug}', name: 'news_show', requirements: ['slug' => '[a-z0-9-]+'])]
+    public function show(string $slug): Response
+    {
+        $item = $this->items->findOnePublishedBySlug($slug);
+        if ($item === null) {
+            throw $this->createNotFoundException('Новость не найдена');
+        }
+
+        return $this->render('tailwind/news/show.html.twig', [
+            'item' => $item,
+        ]);
+    }
+}

--- a/src/Entity/NewsItem.php
+++ b/src/Entity/NewsItem.php
@@ -1,0 +1,165 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity;
+
+use App\Enum\NewsItemStatus;
+use App\Enum\NewsRubric;
+use App\Repository\NewsItemRepository;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Nevinny\AdminCoreBundle\Entity\Trait\Created;
+
+#[ORM\Entity(repositoryClass: NewsItemRepository::class)]
+#[ORM\Table(name: 'news_item')]
+#[ORM\Index(name: 'IDX_news_item_status', columns: ['status'])]
+#[ORM\Index(name: 'IDX_news_item_slug', columns: ['slug'])]
+#[ORM\UniqueConstraint(name: 'UNIQ_news_item_source_guid', columns: ['source_id', 'guid_hash'])]
+#[ORM\HasLifecycleCallbacks]
+class NewsItem
+{
+    use Created;
+
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    private ?int $id = null;
+
+    #[ORM\ManyToOne(targetEntity: NewsSource::class)]
+    #[ORM\JoinColumn(name: 'source_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
+    private NewsSource $source;
+
+    /** sha256 нормализованного guid/URL — дедупликация в пределах источника. */
+    #[ORM\Column(name: 'guid_hash', length: 64)]
+    private string $guidHash;
+
+    #[ORM\Column(length: 512)]
+    private string $url;
+
+    /** Публичный слаг из транслита заголовка; уникален. Null до ready. */
+    #[ORM\Column(length: 255, unique: true, nullable: true)]
+    private ?string $slug = null;
+
+    /** Заголовок из фида (сырой). */
+    #[ORM\Column(length: 512)]
+    private string $title;
+
+    /** Имя издания для атрибуции «По материалам …» (денормализация от source). */
+    #[ORM\Column(name: 'source_name', length: 255)]
+    private string $sourceName;
+
+    /** Ссылка на оригинал для постоянного dofollow. */
+    #[ORM\Column(name: 'source_url', length: 512)]
+    private string $sourceUrl;
+
+    /** Дата выхода оригинала (из фида). */
+    #[ORM\Column(type: Types::DATETIME_MUTABLE, nullable: true)]
+    private ?\DateTime $publishedAt = null;
+
+    /** Исходный текст статьи (доказательство трансформации при претензии). */
+    #[ORM\Column(name: 'raw_fetched_text', type: Types::TEXT, nullable: true)]
+    private ?string $rawFetchedText = null;
+
+    #[ORM\Column(name: 'rewritten_title', length: 512, nullable: true)]
+    private ?string $rewrittenTitle = null;
+
+    #[ORM\Column(name: 'rewritten_body', type: Types::TEXT, nullable: true)]
+    private ?string $rewrittenBody = null;
+
+    /** Когда item стал ready — кап «готовых к публикации» ≤8/день считается по нему. */
+    #[ORM\Column(name: 'ready_at', type: Types::DATETIME_MUTABLE, nullable: true)]
+    private ?\DateTime $readyAt = null;
+
+    #[ORM\Column(length: 16, nullable: true, enumType: NewsRubric::class)]
+    private ?NewsRubric $rubric = null;
+
+    /** Доля совпадающих 5-грамм с исходником; гейт ≤0.10 (_docs/news-sources-tos.md §2.1). */
+    #[ORM\Column(name: 'shingle_score', type: Types::FLOAT, nullable: true)]
+    private ?float $shingleScore = null;
+
+    #[ORM\Column(length: 16, enumType: NewsItemStatus::class, options: ['default' => 'discovered'])]
+    private NewsItemStatus $status = NewsItemStatus::Discovered;
+
+    /**
+     * Карта переходов статус → момент (ATOM): {discovered, fetched, rewritten,
+     * ready, published|rejected}. JSON — история без доп-таблицы.
+     *
+     * @var array<string, string>
+     */
+    #[ORM\Column(name: 'status_timestamps', type: Types::JSON, nullable: true)]
+    private array $statusTimestamps = [];
+
+    /** Почему rejected (шингл-гейт / ручная модерация). */
+    #[ORM\Column(name: 'reject_reason', length: 255, nullable: true)]
+    private ?string $rejectReason = null;
+
+    public function getId(): ?int { return $this->id; }
+
+    public function getSource(): NewsSource { return $this->source; }
+    public function setSource(NewsSource $source): static { $this->source = $source; return $this; }
+
+    public function getGuidHash(): string { return $this->guidHash; }
+    public function setGuidHash(string $guidHash): static { $this->guidHash = $guidHash; return $this; }
+
+    public function getUrl(): string { return $this->url; }
+    public function setUrl(string $url): static { $this->url = $url; return $this; }
+
+    public function getSlug(): ?string { return $this->slug; }
+    public function setSlug(?string $slug): static { $this->slug = $slug; return $this; }
+
+    public function getTitle(): string { return $this->title; }
+    public function setTitle(string $title): static { $this->title = $title; return $this; }
+
+    public function getSourceName(): string { return $this->sourceName; }
+    public function setSourceName(string $sourceName): static { $this->sourceName = $sourceName; return $this; }
+
+    public function getSourceUrl(): string { return $this->sourceUrl; }
+    public function setSourceUrl(string $sourceUrl): static { $this->sourceUrl = $sourceUrl; return $this; }
+
+    public function getPublishedAt(): ?\DateTime { return $this->publishedAt; }
+    public function setPublishedAt(?\DateTime $publishedAt): static { $this->publishedAt = $publishedAt; return $this; }
+
+    public function getRawFetchedText(): ?string { return $this->rawFetchedText; }
+    public function setRawFetchedText(?string $rawFetchedText): static { $this->rawFetchedText = $rawFetchedText; return $this; }
+
+    public function getRewrittenTitle(): ?string { return $this->rewrittenTitle; }
+    public function setRewrittenTitle(?string $rewrittenTitle): static { $this->rewrittenTitle = $rewrittenTitle; return $this; }
+
+    public function getRewrittenBody(): ?string { return $this->rewrittenBody; }
+    public function setRewrittenBody(?string $rewrittenBody): static { $this->rewrittenBody = $rewrittenBody; return $this; }
+
+    public function getReadyAt(): ?\DateTime { return $this->readyAt; }
+    public function setReadyAt(?\DateTime $readyAt): static { $this->readyAt = $readyAt; return $this; }
+
+    public function getRubric(): ?NewsRubric { return $this->rubric; }
+    public function setRubric(?NewsRubric $rubric): static { $this->rubric = $rubric; return $this; }
+
+    public function getShingleScore(): ?float { return $this->shingleScore; }
+    public function setShingleScore(?float $shingleScore): static { $this->shingleScore = $shingleScore; return $this; }
+
+    public function getStatus(): NewsItemStatus { return $this->status; }
+
+    public function setStatus(NewsItemStatus $status): static
+    {
+        $this->status = $status;
+        $this->statusTimestamps[$status->value] = (new \DateTimeImmutable())->format(\DateTimeInterface::ATOM);
+        if ($status === NewsItemStatus::Ready && $this->readyAt === null) {
+            $this->readyAt = new \DateTime();
+        }
+
+        return $this;
+    }
+
+    /** @return array<string, string> */
+    public function getStatusTimestamps(): array { return $this->statusTimestamps; }
+    public function setStatusTimestamps(array $statusTimestamps): static { $this->statusTimestamps = $statusTimestamps; return $this; }
+
+    public function getRejectReason(): ?string { return $this->rejectReason; }
+    public function setRejectReason(?string $rejectReason): static { $this->rejectReason = $rejectReason; return $this; }
+
+    public function __toString(): string
+    {
+        return $this->rewrittenTitle ?? $this->title;
+    }
+}

--- a/src/Entity/NewsSource.php
+++ b/src/Entity/NewsSource.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity;
+
+use App\Repository\NewsSourceRepository;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Nevinny\AdminCoreBundle\Entity\Trait\Created;
+
+#[ORM\Entity(repositoryClass: NewsSourceRepository::class)]
+#[ORM\Table(name: 'news_source')]
+#[ORM\HasLifecycleCallbacks]
+class NewsSource
+{
+    use Created;
+
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    private ?int $id = null;
+
+    #[ORM\Column(length: 255, unique: true)]
+    private string $name;
+
+    #[ORM\Column(name: 'feed_url', length: 512, unique: true)]
+    private string $feedUrl;
+
+    /**
+     * Правовой режим (TosMode): facts_only — только факты; forbidden — жёсткий skip.
+     * Хранится строкой (enumType), чтобы конфиг источников был декларативным
+     * (_docs/news-sources-tos.md, открытый вопрос №5).
+     */
+    #[ORM\Column(name: 'tos_mode', length: 16, enumType: \App\Enum\TosMode::class, options: ['default' => 'facts_only'])]
+    private \App\Enum\TosMode $tosMode = \App\Enum\TosMode::FactsOnly;
+
+    #[ORM\Column(options: ['default' => true])]
+    private bool $active = true;
+
+    /** Подсказка рубрикатору из профиля источника («дети», «мода», …). Nullable. */
+    #[ORM\Column(name: 'rubric_hint', length: 64, nullable: true)]
+    private ?string $rubricHint = null;
+
+    public function getId(): ?int { return $this->id; }
+
+    public function getName(): string { return $this->name; }
+    public function setName(string $name): static { $this->name = $name; return $this; }
+
+    public function getFeedUrl(): string { return $this->feedUrl; }
+    public function setFeedUrl(string $feedUrl): static { $this->feedUrl = $feedUrl; return $this; }
+
+    public function getTosMode(): \App\Enum\TosMode { return $this->tosMode; }
+    public function setTosMode(\App\Enum\TosMode $tosMode): static { $this->tosMode = $tosMode; return $this; }
+
+    public function isActive(): bool { return $this->active; }
+    public function setActive(bool $active): static { $this->active = $active; return $this; }
+
+    public function getRubricHint(): ?string { return $this->rubricHint; }
+    public function setRubricHint(?string $rubricHint): static { $this->rubricHint = $rubricHint; return $this; }
+
+    public function __toString(): string
+    {
+        return $this->name;
+    }
+}

--- a/src/Enum/NewsItemStatus.php
+++ b/src/Enum/NewsItemStatus.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enum;
+
+/**
+ * Жизненный цикл news_item:
+ * discovered → fetched → rewritten → ready → published | rejected.
+ */
+enum NewsItemStatus: string
+{
+    case Discovered = 'discovered'; // найдено в фиде
+    case Fetched    = 'fetched';    // текст статьи догружен
+    case Rewritten  = 'rewritten';  // LLM-рерайт готов (до гейтов)
+    case Ready      = 'ready';      // прошло шингл-гейт, ждёт модерации/автопубликации
+    case Published  = 'published';
+    case Rejected   = 'rejected';   // шингл-гейт или ручной reject
+
+    /** Статусы, которые берёт в работу app:news:process. */
+    public static function processable(): array
+    {
+        return [self::Discovered, self::Fetched];
+    }
+}

--- a/src/Enum/NewsRubric.php
+++ b/src/Enum/NewsRubric.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enum;
+
+/** Рубрикатор wearbase — классифицирует та же LLM, что делает рерайт. */
+enum NewsRubric: string
+{
+    case Fashion = 'fashion';   // мода/тренды
+    case Kids = 'kids';         // дети/родители
+    case Wardrobe = 'wardrobe'; // гардероб/капсулы/уход за вещами
+    case Other = 'other';       // прочее
+
+    public static function tryFromMixed(?string $value): self
+    {
+        $v = mb_strtolower(trim((string) $value));
+        return match (true) {
+            in_array($v, ['мода', 'моде', 'тренды', 'fashion'], true) => self::Fashion,
+            in_array($v, ['дети', 'детское', 'родители', 'kids'], true) => self::Kids,
+            in_array($v, ['гардероб', 'капсула', 'уход за одеждой', 'wardrobe'], true) => self::Wardrobe,
+            default => self::Other,
+        };
+    }
+}

--- a/src/Enum/TosMode.php
+++ b/src/Enum/TosMode.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enum;
+
+/**
+ * Правовой режим источника (см. _docs/news-sources-tos.md):
+ * facts_only — берём только факты, текст пишем сами («заметка на основе фактов»);
+ * forbidden  — правообладатель прямо запретил перепечатку/переработку/автосбор
+ *              (Buro 24/7, РБК Стиль) — жёсткий skip в конвейере.
+ */
+enum TosMode: string
+{
+    case FactsOnly = 'facts_only';
+    case Forbidden = 'forbidden';
+}

--- a/src/Repository/NewsItemRepository.php
+++ b/src/Repository/NewsItemRepository.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repository;
+
+use App\Entity\NewsItem;
+use App\Enum\NewsItemStatus;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @method NewsItem|null find($id, $lockMode = null, $lockVersion = null)
+ * @method NewsItem|null findOneBy(array $criteria, array $orderBy = null)
+ */
+class NewsItemRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, NewsItem::class);
+    }
+
+    public function findBySourceAndGuidHash(int $sourceId, string $guidHash): ?NewsItem
+    {
+        return $this->findOneBy(['source' => $sourceId, 'guidHash' => $guidHash]);
+    }
+
+    /** Очередь process-команды: discovered/fetched, старые вперёд. @return NewsItem[] */
+    public function findProcessable(int $limit): array
+    {
+        return $this->createQueryBuilder('n')
+            ->where('n.status IN (:statuses)')
+            ->setParameter('statuses', NewsItemStatus::processable())
+            ->orderBy('n.id', 'ASC')
+            ->setMaxResults($limit)
+            ->getQuery()
+            ->getResult();
+    }
+
+    /** Сколько item стало ready с начала суток — кап «готовых к публикации» в день. */
+    public function countReadySince(\DateTimeInterface $since): int
+    {
+        return (int) $this->createQueryBuilder('n')
+            ->select('COUNT(n.id)')
+            ->where('n.status = :status')
+            ->andWhere('n.readyAt >= :since')
+            ->setParameter('status', NewsItemStatus::Ready)
+            ->setParameter('since', \DateTime::createFromInterface($since))
+            ->getQuery()
+            ->getSingleScalarResult();
+    }
+
+    /** Лента /news: published, свежие вперёд. @return NewsItem[] */
+    public function findPublished(int $limit, int $offset = 0): array
+    {
+        return $this->createQueryBuilder('n')
+            ->where('n.status = :status')
+            ->setParameter('status', NewsItemStatus::Published)
+            ->orderBy('n.publishedAt', 'DESC')
+            ->addOrderBy('n.id', 'DESC')
+            ->setMaxResults($limit)
+            ->setFirstResult($offset)
+            ->getQuery()
+            ->getResult();
+    }
+
+    public function countPublished(): int
+    {
+        return (int) $this->count(['status' => NewsItemStatus::Published]);
+    }
+
+    public function findOnePublishedBySlug(string $slug): ?NewsItem
+    {
+        return $this->findOneBy(['slug' => $slug, 'status' => NewsItemStatus::Published]);
+    }
+}

--- a/src/Repository/NewsSourceRepository.php
+++ b/src/Repository/NewsSourceRepository.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repository;
+
+use App\Entity\NewsSource;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @method NewsSource|null find($id, $lockMode = null, $lockVersion = null)
+ * @method NewsSource|null findOneBy(array $criteria, array $orderBy = null)
+ * @method NewsSource[]    findAll()
+ * @method NewsSource[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
+ */
+class NewsSourceRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, NewsSource::class);
+    }
+}

--- a/src/Service/News/ArticleTextExtractor.php
+++ b/src/Service/News/ArticleTextExtractor.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\News;
+
+use Symfony\Component\DomCrawler\Crawler;
+
+/**
+ * Извлечение текста статьи из HTML: вырезаем script/style/nav/хром,
+ * берём <article> если есть, иначе body. Возвращает чистый текст
+ * (двойной перевод строки между абзацами) для рерайта и шингл-гейта.
+ */
+final class ArticleTextExtractor
+{
+    private const STRIP_SELECTORS = 'script, style, noscript, iframe, form, svg, nav, header, footer, aside, figure, figcaption';
+
+    /** Минимальный объём текста, ниже которого статья считается недогруженной. */
+    public const MIN_TEXT_LENGTH = 200;
+
+    public function extract(string $html): ?string
+    {
+        if (trim($html) === '') {
+            return null;
+        }
+
+        $crawler = new Crawler($html);
+        $doc = $crawler;
+        try {
+            $root = $crawler->filter('article');
+            if ($root->count() > 0) {
+                $doc = $root->eq(0);
+            }
+        } catch (\Throwable) {
+            // битая разметка — работаем с тем, что распарсилось
+        }
+
+        $doc->filter(self::STRIP_SELECTORS)->each(function (Crawler $node): void {
+            foreach ($node as $el) {
+                $el->parentNode?->removeChild($el);
+            }
+        });
+
+        $text = trim((string) $doc->text(null));
+        // Схлопываем повторяющиеся пустые строки, режем «портянку» пробелов в строке
+        $text = preg_replace('/[ \t\x{00A0}]+/u', ' ', $text) ?? $text;
+        $text = preg_replace("/\n{3,}/", "\n\n", $text) ?? $text;
+
+        return mb_strlen($text) >= self::MIN_TEXT_LENGTH ? $text : null;
+    }
+}

--- a/src/Service/News/HostPoliteness.php
+++ b/src/Service/News/HostPoliteness.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+
+namespace App\Service\News;
+
+/**
+ * Вежливость к источникам: не чаще одного запроса в секунду на хост
+ * (политика конвейера, _docs/news-sources.md §3). Интервал инъектится —
+ * в тестах ставим 0.
+ */
+final class HostPoliteness
+{
+    /** @var array<string, float> host → timestamp последнего запроса */
+    private array $lastRequest = [];
+
+    public function __construct(private readonly float $minIntervalSeconds = 1.0)
+    {
+    }
+
+    /** Блокирует до истечения интервала и фиксирует новый запрос. */
+    public function guard(string $host): void
+    {
+        if ($host === '') {
+            return;
+        }
+
+        $now = microtime(true);
+        $last = $this->lastRequest[$host] ?? null;
+        if ($last !== null) {
+            $wait = $this->minIntervalSeconds - ($now - $last);
+            if ($wait > 0) {
+                usleep((int) ceil($wait * 1_000_000));
+            }
+        }
+        $this->lastRequest[$host] = microtime(true);
+    }
+}

--- a/src/Service/News/NewsLlmClientInterface.php
+++ b/src/Service/News/NewsLlmClientInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\News;
+
+/**
+ * Точка доступа к LLM для новостного конвейера. Интерфейс — чтобы тесты
+ * подсовывали stub/double без сети (ollama в CI недоступна).
+ */
+interface NewsLlmClientInterface
+{
+    /**
+     * Один chat-запрос; возвращает сырой текст ответа модели.
+     *
+     * @param array<int, array{role: string, content: string}> $messages
+     *
+     * @throws NewsLlmUnavailableException если ollama не отвечает / не 2xx
+     */
+    public function chat(array $messages, ?string $format = null): string;
+}

--- a/src/Service/News/NewsLlmUnavailableException.php
+++ b/src/Service/News/NewsLlmUnavailableException.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\News;
+
+/** LLM недоступна (таймаут/сеть/не-2xx): item остаётся в fetched, конвейер не падает. */
+final class NewsLlmUnavailableException extends \RuntimeException
+{
+}

--- a/src/Service/News/NewsRewriter.php
+++ b/src/Service/News/NewsRewriter.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\News;
+
+use App\Enum\NewsRubric;
+
+/**
+ * Рерайт «заметка на основе фактов» (_docs/news-sources.md §2, _docs/news-sources-tos.md §2):
+ * НЕ переписываем чужой текст — пишем собственную заметку только на фактах,
+ * чёрный список жанров (интервью/колонки/топ-N) отсеиваем до рерайта.
+ * Рубрикатор — та же LLM, один вызов возвращает title+body+rubric.
+ */
+final class NewsRewriter
+{
+    public function __construct(private readonly NewsLlmClientInterface $llm)
+    {
+    }
+
+    /** Жанры, которые нельзя рерайтить: охраняется форма/составительство (ст. 1259 п. 2). */
+    private const FORBIDDEN_GENRES = [
+        'интервью', 'опрос', 'колонка', 'мнение', 'блог',
+        'тест', 'гороскоп', 'топ-', 'рейтинг', 'подборка',
+    ];
+
+    public function isForbiddenGenre(string $title): bool
+    {
+        $t = mb_strtolower($title);
+
+        foreach (self::FORBIDDEN_GENRES as $g) {
+            if (str_contains($t, $g)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @return array{title: string, body: string, rubric: NewsRubric}
+     *
+     * @throws \RuntimeException если модель вернула нераспознаваемый ответ
+     * @throws NewsLlmUnavailableException если ollama недоступна
+     */
+    public function rewrite(string $sourceName, string $articleText, ?string $rubricHint = null): array
+    {
+        $system = <<<'TXT'
+Ты редактор российского сайта о моде и гардеробе WEARBASE.
+Тебе дают факты из новости другого издания. Напиши ЗАМЕТКУ НА ОСНОВЕ ФАКТОВ:
+- используй ТОЛЬКО факты из исходника, никаких домыслов;
+- текст полностью свой: не копируй фразы и предложения исходника;
+- 3–6 абзацев простым языком, без заголовков внутри;
+- не вставляй ссылки и упоминания «наш сайт»;
+- ответ строго в JSON: {"title": "…", "body": "…", "rubric": "fashion|kids|wardrobe|other"}
+TXT;
+
+        $user = sprintf(
+            "Издание: %s%s\n\nФакты:\n%s",
+            $sourceName,
+            $rubricHint !== null ? "\nОжидаемая тематика: " . $rubricHint : '',
+            mb_substr($articleText, 0, 8000),
+        );
+
+        $raw = $this->llm->chat([
+            ['role' => 'system', 'content' => $system],
+            ['role' => 'user', 'content' => $user],
+        ], 'json');
+
+        $parsed = json_decode($this->stripReasoning($raw), true);
+        if (!is_array($parsed) || !isset($parsed['title'], $parsed['body'])) {
+            throw new \RuntimeException('LLM вернула ответ не в ожидаемом JSON');
+        }
+
+        $title = trim((string) $parsed['title']);
+        $body = trim((string) $parsed['body']);
+        if ($title === '' || mb_strlen($body) < self::MIN_BODY_LENGTH) {
+            throw new \RuntimeException('Пустой/слишком короткий ответ LLM');
+        }
+
+        return [
+            'title' => $title,
+            'body' => $body,
+            'rubric' => NewsRubric::tryFromMixed($parsed['rubric'] ?? null),
+        ];
+    }
+
+    /** qwen3 может оборачивать ответ в <think>…</think> или ```json-фенсы. */
+    public function stripReasoning(string $raw): string
+    {
+        $s = preg_replace('~<think>.*?</think>~is', '', $raw) ?? $raw;
+        $s = preg_replace('~```(?:json)?\s*|```~i', '', $s) ?? $s;
+
+        return trim($s);
+    }
+
+    private const MIN_BODY_LENGTH = 300;
+}

--- a/src/Service/News/NewsSlugger.php
+++ b/src/Service/News/NewsSlugger.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\News;
+
+/**
+ * Публичный слаг заметки: транслит заголовка (та же карта, что CitySlugger),
+ * уникальность добивается суффиксом -2, -3…
+ */
+final class NewsSlugger
+{
+    private const MAP = [
+        'а' => 'a', 'б' => 'b', 'в' => 'v', 'г' => 'g', 'д' => 'd',
+        'е' => 'e', 'ё' => 'e', 'ж' => 'zh', 'з' => 'z', 'и' => 'i',
+        'й' => 'y', 'к' => 'k', 'л' => 'l', 'м' => 'm', 'н' => 'n',
+        'о' => 'o', 'п' => 'p', 'р' => 'r', 'с' => 's', 'т' => 't',
+        'у' => 'u', 'ф' => 'f', 'х' => 'kh', 'ц' => 'ts', 'ч' => 'ch',
+        'ш' => 'sh', 'щ' => 'sch', 'ъ' => '', 'ы' => 'y', 'ь' => '',
+        'э' => 'e', 'ю' => 'yu', 'я' => 'ya',
+    ];
+
+    public function slugify(string $title): string
+    {
+        $s = mb_strtolower(trim($title));
+        $s = strtr($s, self::MAP);
+        $s = preg_replace('/[^a-z0-9]+/', '-', $s) ?? '';
+        $slug = trim($s, '-');
+
+        return substr($slug, 0, 180) !== '' ? substr($slug, 0, 180) : 'news';
+    }
+}

--- a/src/Service/News/NewsSourcesCatalog.php
+++ b/src/Service/News/NewsSourcesCatalog.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\News;
+
+use App\Enum\TosMode;
+
+/**
+ * Каталог MVP-источников (единая правда для миграции и app:news:sources:seed).
+ * Фиды проверены чтением 2026-08-25 (_docs/news-sources.md §1),
+ * правовые режимы — _docs/news-sources-tos.md.
+ */
+final class NewsSourcesCatalog
+{
+    /**
+     * @return array<int, array{name: string, feedUrl: string, tosMode: TosMode, active: bool, rubricHint: ?string}>
+     */
+    public static function all(): array
+    {
+        return [
+            // ── MVP: 4 факто-only источника ────────────────────────────────
+            ['name' => 'Parents.ru', 'feedUrl' => 'https://www.parents.ru/rss-feeds/rss.xml', 'tosMode' => TosMode::FactsOnly, 'active' => true, 'rubricHint' => 'дети'],
+            ['name' => 'Woman.ru', 'feedUrl' => 'https://www.woman.ru/rss/', 'tosMode' => TosMode::FactsOnly, 'active' => true, 'rubricHint' => 'мода'],
+            ['name' => 'The-Day', 'feedUrl' => 'https://the-day.ru/rss-feeds/rss.xml', 'tosMode' => TosMode::FactsOnly, 'active' => true, 'rubricHint' => null],
+            ['name' => 'Sobaka.ru', 'feedUrl' => 'https://www.sobaka.ru/rss/news.xml', 'tosMode' => TosMode::FactsOnly, 'active' => true, 'rubricHint' => null],
+            // ── Запрещённые правообладателем: в конвейере не участвуют ────
+            ['name' => 'Buro 24/7', 'feedUrl' => 'https://www.buro247.ru/xml/rss.xml', 'tosMode' => TosMode::Forbidden, 'active' => false, 'rubricHint' => null],
+            ['name' => 'РБК Стиль', 'feedUrl' => 'https://style.rbc.ru/', 'tosMode' => TosMode::Forbidden, 'active' => false, 'rubricHint' => null],
+        ];
+    }
+}

--- a/src/Service/News/OllamaClient.php
+++ b/src/Service/News/OllamaClient.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\News;
+
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * Ollama HTTP-клиент (/api/chat). URL и модель из env:
+ * OLLAMA_URL (по умолчанию http://127.0.0.1:11434), OLLAMA_MODEL
+ * (по умолчанию qwen3.5:27b — проверенная текстовая модель этого стека,
+ * см. BenchModelsCommand).
+ */
+final class OllamaClient implements NewsLlmClientInterface
+{
+    private string $baseUrl;
+
+    public function __construct(
+        private readonly HttpClientInterface $httpClient,
+        ?string $ollamaUrl = null,
+        private readonly string $model = 'qwen3.5:27b',
+        private readonly float $timeoutSeconds = 120.0,
+    ) {
+        $this->baseUrl = rtrim($ollamaUrl ?: self::DEFAULT_URL, '/');
+    }
+
+    public function chat(array $messages, ?string $format = null): string
+    {
+        $payload = [
+            'model' => $this->model,
+            'messages' => $messages,
+            'stream' => false,
+            'options' => ['temperature' => 0.4],
+        ];
+        if ($format !== null) {
+            $payload['format'] = $format;
+        }
+
+        try {
+            $resp = $this->httpClient->request('POST', $this->baseUrl . '/api/chat', [
+                'json' => $payload,
+                'timeout' => $this->timeoutSeconds,
+            ]);
+            $data = json_decode($resp->getContent(), true, flags: JSON_THROW_ON_ERROR);
+        } catch (\Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface |
+                 \Symfony\Contracts\HttpClient\Exception\HttpExceptionInterface |
+                 \JsonException $e
+        ) {
+            throw new NewsLlmUnavailableException('ollama недоступна: ' . $e->getMessage(), previous: $e);
+        }
+
+        return trim((string) ($data['message']['content'] ?? ''));
+    }
+}

--- a/src/Service/News/RssParser.php
+++ b/src/Service/News/RssParser.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\News;
+
+/**
+ * Минимальный RSS 2.0-парсер: все MVP-фиды — стандартный RSS, различается
+ * только путь до <item> (_docs/news-sources.md §3). Namespace-префиксы
+ * (content:, dc:) игнорируем — берём title/link/guid/pubDate/description.
+ *
+ * @return array<int, array{guid: string, link: string, title: string, pubDate: ?\DateTimeImmutable, description: string}>
+ */
+final class RssParser
+{
+    /**
+     * @throws \RuntimeException при невалидном XML
+     */
+    public function parse(string $xml): array
+    {
+        $prev = libxml_use_internal_errors(true);
+        try {
+            $root = simplexml_load_string($xml, \SimpleXMLElement::class, LIBXML_NOCDATA);
+            if ($root === false) {
+                throw new \RuntimeException('Невалидный RSS/XML');
+            }
+        } finally {
+            libxml_clear_errors();
+            libxml_use_internal_errors($prev);
+        }
+
+        $items = [];
+        foreach ($root->xpath('//*[local-name()="item"]') ?: [] as $node) {
+            $link = trim((string) ($node->xpath('./*[local-name()="link"]')[0] ?? ''));
+            if ($link === '') {
+                continue;
+            }
+
+            $pubRaw = trim((string) ($node->xpath('./*[local-name()="pubDate"]')[0] ?? ''));
+            $pub = null;
+            if ($pubRaw !== '') {
+                $ts = strtotime($pubRaw);
+                $pub = $ts !== false ? (new \DateTimeImmutable())->setTimestamp($ts) : null;
+            }
+
+            $items[] = [
+                'guid' => trim((string) ($node->xpath('./*[local-name()="guid"]')[0] ?? '')),
+                'link' => $link,
+                'title' => html_entity_decode(trim((string) ($node->xpath('./*[local-name()="title"]')[0] ?? '')), ENT_QUOTES),
+                'pubDate' => $pub,
+                'description' => html_entity_decode(trim(strip_tags((string) ($node->xpath('./*[local-name()="description"]')[0] ?? ''))), ENT_QUOTES),
+            ];
+        }
+
+        return $items;
+    }
+}

--- a/src/Service/News/ShingleGate.php
+++ b/src/Service/News/ShingleGate.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\News;
+
+/**
+ * Шингл-гейт плагиата (_docs/news-sources-tos.md §2.1): доля 5-словных
+ * шинглов рерайта, встретившихся в исходнике, должна быть ≤10%.
+ * Запас легальности нулевой (запрет воспроизведения у всех MVP-источников),
+ * поэтому порог жёстче плановых 10–15%.
+ */
+final class ShingleGate
+{
+    public const N = 5;
+    public const THRESHOLD = 0.10;
+
+    /**
+     * Доля шинглов рерайта, совпавших с исходником (containment по rewrite).
+     *
+     * @param int<1, max> $n
+     */
+    public function overlap(string $source, string $rewrite, int $n = self::N): float
+    {
+        $sourceShingles = $this->shingles($source, $n);
+        if ($sourceShingles === []) {
+            return 0.0;
+        }
+
+        $rewriteShingles = array_values(array_unique($this->rawShingles($rewrite, $n)));
+        if ($rewriteShingles === []) {
+            return 0.0;
+        }
+
+        $hits = 0;
+        foreach ($rewriteShingles as $shingle) {
+            if (isset($sourceShingles[$shingle])) {
+                ++$hits;
+            }
+        }
+
+        return $hits / count($rewriteShingles);
+    }
+
+    public function passes(float $score): bool
+    {
+        return $score <= self::THRESHOLD;
+    }
+
+    /** @return array<string, true> уникальные шинглы → true */
+    private function shingles(string $text, int $n): array
+    {
+        $out = [];
+        foreach ($this->rawShingles($text, $n) as $s) {
+            $out[$s] = true;
+        }
+
+        return $out;
+    }
+
+    /** @return string[] */
+    private function rawShingles(string $text, int $n): array
+    {
+        $words = $this->words($text);
+        if (count($words) < $n) {
+            return [];
+        }
+
+        $shingles = [];
+        for ($i = 0, $c = count($words) - $n; $i <= $c; ++$i) {
+            $shingles[] = implode(' ', array_slice($words, $i, $n));
+        }
+
+        return $shingles;
+    }
+
+    /** @return string[] */
+    private function words(string $text): array
+    {
+        return preg_split('/[^a-zа-яё0-9]+/ui', mb_strtolower($text), -1, PREG_SPLIT_NO_EMPTY) ?: [];
+    }
+}

--- a/src/Service/News/UrlNormalizer.php
+++ b/src/Service/News/UrlNormalizer.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\News;
+
+/**
+ * Нормализация URL для дедупликации: одинаковые ссылки из фида и из статьи
+ * должны дать один хеш (регистр хоста, трекинг-параметры, fragment, слэш в конце).
+ */
+final class UrlNormalizer
+{
+    private const TRACKING_PARAMS = [
+        'utm_source', 'utm_medium', 'utm_campaign', 'utm_content', 'utm_term',
+        'utm_referrer', 'fbclid', 'gclid', 'yclid', 'from', 'ref', 'amp',
+    ];
+
+    public function normalize(string $url): string
+    {
+        $p = parse_url(trim($url));
+        if ($p === false || !isset($p['host'])) {
+            return trim($url);
+        }
+
+        $scheme = strtolower($p['scheme'] ?? 'https');
+        $host = strtolower($p['host']);
+        // www.X → X: издания сами не консистентны между фидом и сайтом
+        $host = preg_replace('~^www\.~', '', $host) ?? $host;
+
+        $path = $p['path'] ?? '';
+        if ($path !== '' && $path !== '/') {
+            $path = rtrim($path, '/');
+        }
+
+        parse_str($p['query'] ?? '', $query);
+        foreach (self::TRACKING_PARAMS as $param) {
+            unset($query[$param]);
+        }
+        ksort($query);
+        $qs = http_build_query($query);
+
+        return $scheme . '://' . $host . $path . ($qs !== '' ? '?' . $qs : '');
+    }
+
+    /** Стабильный ключ дедупликации: guid, а если пуст — нормализованный URL. */
+    public function guidHash(string $guid, string $link): string
+    {
+        $key = trim($guid) !== '' ? $this->normalize($guid) : $this->normalize($link);
+
+        return hash('sha256', $key);
+    }
+}

--- a/templates/tailwind/news/index.html.twig
+++ b/templates/tailwind/news/index.html.twig
@@ -1,0 +1,53 @@
+{% extends 'tailwind/base.html.twig' %}
+
+{% block title %}Новости моды и гардероба | WEARBASE{% endblock %}
+
+{% block meta_description %}Свежие новости моды, детской одежды и гардероба — кратко и по фактам.{% endblock %}
+
+{% block og_title %}Новости моды и гардероба | WEARBASE{% endblock %}
+
+{# Self-canonical: первая страница без ?page, пагинация — со страницей #}
+{% block canonical_url %}{{ url('news_index') ~ (page > 1 ? '?page=' ~ page : '') }}{% endblock %}
+
+{% block body %}
+    <div class="container mx-auto px-4 py-10 max-w-3xl">
+        <nav class="flex mb-6 text-sm" aria-label="Хлебные крошки">
+            <a href="{{ path('home_hub', {_locale: 'ru'}) }}" class="text-gray-500 hover:text-gray-900">Главная</a>
+            <span class="mx-2 text-gray-400">/</span>
+            <span class="text-gray-900 font-medium">Новости</span>
+        </nav>
+
+        <h1 class="text-3xl md:text-4xl font-bold">Новости</h1>
+
+        {% if items is empty %}
+            <p class="text-gray-500 mt-8">Пока пусто — новости появятся совсем скоро.</p>
+        {% else %}
+            <div class="mt-8 space-y-8">
+                {% for item in items %}
+                    <article>
+                        <p class="text-xs uppercase tracking-wide text-gray-400">
+                            {{ item.rubric.value }} · {{ (item.readyAt ?: item.createdAt)|date('d.m.Y') }}
+                        </p>
+                        <h2 class="text-xl font-semibold mt-1">
+                            <a href="{{ path('news_show', {slug: item.slug}) }}" class="hover:underline">{{ item.rewrittenTitle }}</a>
+                        </h2>
+                        <p class="text-gray-600 mt-2">{{ item.rewrittenBody|striptags|slice(0, 180) }}…</p>
+                        <p class="text-sm text-gray-400 mt-1">По материалам {{ item.sourceName }}</p>
+                    </article>
+                {% endfor %}
+            </div>
+
+            {% if totalPages > 1 %}
+                <nav class="flex gap-3 mt-10 text-sm" aria-label="Страницы">
+                    {% for p in 1..totalPages %}
+                        {% if p == page %}
+                            <span class="font-bold text-gray-900">{{ p }}</span>
+                        {% else %}
+                            <a href="{{ path('news_index', {page: p}) }}" class="text-gray-500 hover:text-gray-900">{{ p }}</a>
+                        {% endif %}
+                    {% endfor %}
+                </nav>
+            {% endif %}
+        {% endif %}
+    </div>
+{% endblock %}

--- a/templates/tailwind/news/show.html.twig
+++ b/templates/tailwind/news/show.html.twig
@@ -1,0 +1,61 @@
+{% extends 'tailwind/base.html.twig' %}
+
+{% block title %}{{ item.rewrittenTitle }} | WEARBASE{% endblock %}
+
+{% block meta_description %}{{ item.rewrittenBody|striptags|slice(0, 155) }}{% endblock %}
+
+{% block og_title %}{{ item.rewrittenTitle }} | WEARBASE{% endblock %}
+
+{% block og_description %}{{ item.rewrittenBody|striptags|slice(0, 155) }}{% endblock %}
+
+{# Self-canonical: страница индексируема (без noindex) #}
+{% block canonical_url %}{{ url('news_show', {slug: item.slug}) }}{% endblock %}
+
+{% block structured_data %}
+    <script type="application/ld+json">
+    {
+        "@context": "https://schema.org",
+        "@type": "NewsArticle",
+        "headline": {{ item.rewrittenTitle|json_encode|raw }},
+        "datePublished": "{{ (item.readyAt ?: item.createdAt)|date('c') }}",
+        "inLanguage": "ru",
+        "mainEntityOfPage": "{{ url('news_show', {slug: item.slug}) }}",
+        "author": {"@type": "Organization", "name": "WEARBASE", "url": "https://wearbase.ru"},
+        "publisher": {"@type": "Organization", "name": "WEARBASE", "url": "https://wearbase.ru"},
+        "isBasedOn": {{ item.sourceUrl|json_encode|raw }}
+    }
+    </script>
+{% endblock %}
+
+{% block body %}
+    <div class="container mx-auto px-4 py-10 max-w-3xl">
+        <nav class="flex mb-6 text-sm" aria-label="Хлебные крошки">
+            <a href="{{ path('home_hub', {_locale: 'ru'}) }}" class="text-gray-500 hover:text-gray-900">Главная</a>
+            <span class="mx-2 text-gray-400">/</span>
+            <a href="{{ path('news_index') }}" class="text-gray-500 hover:text-gray-900">Новости</a>
+            <span class="mx-2 text-gray-400">/</span>
+            <span class="text-gray-900 font-medium">{{ item.rewrittenTitle|slice(0, 60) }}</span>
+        </nav>
+
+        <article>
+            <header class="mb-8">
+                <p class="text-xs uppercase tracking-wide text-gray-400">{{ item.rubric.value }}</p>
+                <h1 class="text-3xl md:text-4xl font-bold mt-2">{{ item.rewrittenTitle }}</h1>
+                <time datetime="{{ (item.readyAt ?: item.createdAt)|date('Y-m-d') }}" class="block text-sm text-gray-400 mt-3">
+                    {{ (item.readyAt ?: item.createdAt)|date('d.m.Y') }}
+                </time>
+                {# Обязательная атрибуция первоисточника: постоянный dofollow #}
+                <p class="text-sm text-gray-500 mt-3">
+                    По материалам
+                    <a href="{{ item.sourceUrl }}" rel="noopener" class="underline hover:text-gray-800">{{ item.sourceName }}</a>
+                </p>
+            </header>
+
+            <div class="prose prose-lg max-w-none [&_p]:mt-4">
+                {% for paragraph in item.rewrittenBody|split("\n\n") %}
+                    <p>{{ paragraph }}</p>
+                {% endfor %}
+            </div>
+        </article>
+    </div>
+{% endblock %}

--- a/tests/Command/NewsPipelineTest.php
+++ b/tests/Command/NewsPipelineTest.php
@@ -1,0 +1,321 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Command;
+
+use App\Command\NewsFetchCommand;
+use App\Command\NewsProcessCommand;
+use App\Entity\NewsItem;
+use App\Entity\NewsSource;
+use App\Enum\NewsItemStatus;
+use App\Enum\TosMode;
+use App\Repository\NewsItemRepository;
+use App\Repository\NewsSourceRepository;
+use App\Service\News\ArticleTextExtractor;
+use App\Service\News\HostPoliteness;
+use App\Service\News\NewsLlmClientInterface;
+use App\Service\News\NewsLlmUnavailableException;
+use App\Service\News\NewsRewriter;
+use App\Service\News\NewsSlugger;
+use App\Service\News\RssParser;
+use App\Service\News\ShingleGate;
+use App\Service\News\UrlNormalizer;
+use Doctrine\ORM\EntityManagerInterface;
+use Psr\Log\NullLogger;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+/**
+ * Тесты новостного конвейера: дедуп fetch, жёсткий skip forbidden,
+ * шингл-гейт, дневной кап 8/день, устойчивость к недоступной ollama.
+ * LLM и сеть — стабы (MockHttpClient / stub NewsLlmClientInterface).
+ */
+final class NewsPipelineTest extends WebTestCase
+{
+    private const RSS = <<<'XML'
+        <?xml version="1.0" encoding="UTF-8"?>
+        <rss version="2.0"><channel><title>t</title>
+        <item><guid>g-1</guid><link>https://www.parents.test/news/article-one</link>
+            <title>Первая новость</title><pubDate>Mon, 24 Aug 2026 10:00:00 +0300</pubDate></item>
+        <item><guid>g-2</guid><link>https://www.parents.test/news/article-two</link>
+            <title>Вторая новость</title></item>
+        </channel></rss>
+        XML;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $this->em()->createQuery('DELETE FROM App\Entity\NewsItem')->execute();
+        $this->em()->createQuery('DELETE FROM App\Entity\NewsSource')->execute();
+        static::ensureKernelShutdown();
+    }
+
+    public function testFetchDeduplicatesOnSecondRun(): void
+    {
+        $source = $this->createSource('Parents.test', TosMode::FactsOnly);
+        $fetcher = $this->buildFetcher(new MockHttpClient([new MockResponse(self::RSS), new MockResponse(self::RSS)]));
+
+        [$code, $out] = $this->runCommand($fetcher);
+        self::assertSame(Command::SUCCESS, $code);
+        self::assertSame(2, $this->countItems($source->getId()), $out);
+        self::assertStringContainsString('Fetched: 2 new item(s)', $out);
+
+        // Повторный запуск по тому же фиду не создаёт дублей
+        [, $out2] = $this->runCommand($fetcher);
+        self::assertSame(2, $this->countItems($source->getId()));
+        self::assertStringContainsString('Fetched: 0 new item(s)', $out2);
+
+        // guid из фида нормализуется в стабильный хеш
+        $first = $this->itemsRepo()->findOneBy(['guidHash' => hash('sha256', 'g-1')]);
+        self::assertNotNull($first);
+        self::assertSame(NewsItemStatus::Discovered, $first->getStatus());
+        self::assertSame('2026-08-24', $first->getPublishedAt()?->format('Y-m-d'));
+    }
+
+    public function testForbiddenSourceIsHardSkippedEvenIfActive(): void
+    {
+        $source = $this->createSource('Buro.test', TosMode::Forbidden);
+
+        $requests = 0;
+        $client = new MockHttpClient(function (string $method, string $url) use (&$requests): MockResponse {
+            ++$requests;
+
+            return new MockResponse('');
+        });
+
+        [$code, $out] = $this->runCommand($this->buildFetcher($client));
+
+        self::assertSame(Command::SUCCESS, $code);
+        self::assertStringContainsString('[skip-tos] Buro.test (forbidden)', $out);
+        self::assertStringContainsString('Fetched: 0 new item(s), 1 skipped by ToS', $out);
+        self::assertSame(0, $requests, 'forbidden-источник не должен опрашиваться вообще');
+        self::assertSame(0, $this->countItems($source->getId()));
+    }
+
+    public function testShingleGateRejectsNearCopy(): void
+    {
+        $text = $this->longText();
+
+        // Stub-LLM вернул почти копию исходника — гейт обязан реджектить.
+        $llm = new FixedLlmStub(json_encode([
+            'title' => 'Копия исходника',
+            'body' => mb_substr($text, 0, 1200),
+            'rubric' => 'fashion',
+        ], JSON_THROW_ON_ERROR));
+
+        [$itemId] = $this->createFetchedItem($text);
+        [$code, $out] = $this->runProcessor($llm);
+
+        self::assertSame(Command::SUCCESS, $code);
+        /** @var NewsItem $fresh */
+        $fresh = $this->itemsRepo()->find($itemId);
+        self::assertSame(NewsItemStatus::Rejected, $fresh->getStatus(), $out);
+        self::assertStringStartsWith('shingle_gate:', (string) $fresh->getRejectReason());
+        self::assertGreaterThan(ShingleGate::THRESHOLD, $fresh->getShingleScore() ?? 0);
+    }
+
+    public function testDailyCapAllowsAtMostEightReady(): void
+    {
+        for ($i = 0; $i < 10; ++$i) {
+            $this->createFetchedItem('Исходник номер ' . $i . ': ' . $this->longText('словарь-' . $i . '-'));
+        }
+
+        [, $out] = $this->runProcessor(new UniqueLlmStub());
+
+        self::assertSame(8, $this->itemsRepo()->count(['status' => NewsItemStatus::Ready]), 'кап готовых к публикации ≤8/день: ' . $out);
+        self::assertSame(2, $this->itemsRepo()->count(['status' => NewsItemStatus::Rewritten]), 'лишние остаются в rewritten до следующего дня');
+
+        foreach ($this->itemsRepo()->findBy(['status' => NewsItemStatus::Ready]) as $readyItem) {
+            self::assertNotNull($readyItem->getSlug(), 'слаг проставляется при ready');
+        }
+    }
+
+    public function testOllamaUnavailableKeepsItemInFetchedWithoutCrash(): void
+    {
+        [$itemId] = $this->createFetchedItem($this->longText());
+
+        $unavailable = new class implements NewsLlmClientInterface {
+            public function chat(array $messages, ?string $format = null): string
+            {
+                throw new NewsLlmUnavailableException('connection refused');
+            }
+        };
+
+        [$code, $out] = $this->runProcessor($unavailable);
+
+        self::assertSame(Command::SUCCESS, $code, 'конвейер не должен падать при недоступной ollama');
+        /** @var NewsItem $fresh */
+        $fresh = $this->itemsRepo()->find($itemId);
+        self::assertSame(NewsItemStatus::Fetched, $fresh->getStatus(), $out);
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────
+
+    private function buildFetcher(MockHttpClient $client): NewsFetchCommand
+    {
+        return new NewsFetchCommand(
+            $this->em(),
+            $client,
+            new RssParser(),
+            new UrlNormalizer(),
+            new HostPoliteness(0.0),
+            $this->em()->getRepository(NewsSource::class),
+            new NullLogger(),
+        );
+    }
+
+    /** @return array{int, string} */
+    private function runProcessor(NewsLlmClientInterface $llm): array
+    {
+        return $this->runCommand(new NewsProcessCommand(
+            $this->em(),
+            new MockHttpClient(),
+            $this->itemsRepo(),
+            new NewsRewriter($llm),
+            new ArticleTextExtractor(),
+            new ShingleGate(),
+            new NewsSlugger(),
+            new HostPoliteness(0.0),
+            new NullLogger(),
+            autoPublish: false,
+        ), ['--limit' => '50']);
+    }
+
+    /**
+     * Команда собирается на EM текущего kernel и выполняется в том же boot —
+     * без shutdown между сборкой и execute.
+     *
+     * @return array{int, string}
+     */
+    private function runCommand(Command $command, array $args = []): array
+    {
+        // Команда собрана на EM уже загруженного kernel — выполняем в том же boot,
+        // иначе "kernel should only be booted once".
+        if (self::$kernel === null) {
+            static::bootKernel();
+        }
+        $app = new Application(self::$kernel);
+        $app->add($command);
+        $tester = new CommandTester($app->find($command->getName()));
+        $code = $tester->execute($args);
+        $out = $tester->getDisplay();
+        static::ensureKernelShutdown();
+
+        return [$code, $out];
+    }
+
+    private function em(): EntityManagerInterface
+    {
+        return static::getContainer()->get('doctrine.orm.entity_manager');
+    }
+
+    private function itemsRepo(): NewsItemRepository
+    {
+        return $this->em()->getRepository(NewsItem::class);
+    }
+
+    private function countItems(int $sourceId): int
+    {
+        return $this->itemsRepo()->count(['source' => $sourceId]);
+    }
+
+    private function createSource(string $name, TosMode $tosMode, bool $active = true): NewsSource
+    {
+
+        $source = (new NewsSource())
+            ->setName($name)
+            ->setFeedUrl(sprintf('https://www.%s/rss.xml', mb_strtolower(str_replace('.', '', $name))))
+            ->setTosMode($tosMode)
+            ->setActive($active);
+        $this->em()->persist($source);
+        $this->em()->flush();
+        static::ensureKernelShutdown();
+
+        return $source; // detached, годится для id/name
+    }
+
+    /** @return array{int, string} id и имя источника не нужны — только id item */
+    private function createFetchedItem(string $rawText): array
+    {
+        static $seq = 0;
+        ++$seq;
+
+
+        $em = $this->em();
+        $source = $em->getRepository(NewsSource::class)->findOneBy([]);
+        if ($source === null) {
+            $source = (new NewsSource())
+                ->setName('Parents.test')
+                ->setFeedUrl('https://www.parentstest/rss.xml')
+                ->setTosMode(TosMode::FactsOnly)
+                ->setActive(true);
+            $em->persist($source);
+            $em->flush();
+        }
+
+        $item = (new NewsItem())
+            ->setSource($source)
+            ->setGuidHash('hash-' . $seq . '-' . bin2hex(random_bytes(4)))
+            ->setUrl('https://parents.test/article-' . $seq)
+            ->setTitle('Новость ' . $seq)
+            ->setSourceName($source->getName())
+            ->setSourceUrl('https://parents.test/article-' . $seq)
+            ->setRawFetchedText($rawText)
+            ->setStatus(NewsItemStatus::Fetched);
+        $em->persist($item);
+        $em->flush();
+        $id = $item->getId() ?? throw new \RuntimeException('no id after flush');
+        static::ensureKernelShutdown();
+
+        return [$id];
+    }
+
+    private function longText(string $prefix = 'факт-'): string
+    {
+        $sentences = [];
+        for ($i = 0; $i < 60; ++$i) {
+            $sentences[] = sprintf('%s%s факт номер %d про моду и гардероб города.', $prefix, $i, $i);
+        }
+
+        return implode(' ', $sentences);
+    }
+}
+
+/** LLM-стаб с фиксированным ответом (для шингл-гейта). */
+final class FixedLlmStub implements NewsLlmClientInterface
+{
+    public function __construct(private readonly string $response)
+    {
+    }
+
+    public function chat(array $messages, ?string $format = null): string
+    {
+        return $this->response;
+    }
+}
+
+/** LLM-стаб, выдающий каждый раз уникальную заметку (мимо шингл-гейта). */
+final class UniqueLlmStub implements NewsLlmClientInterface
+{
+    private int $n = 0;
+
+    public function chat(array $messages, ?string $format = null): string
+    {
+        ++$this->n;
+        $words = [];
+        for ($i = 0; $i < 90; ++$i) {
+            $words[] = sprintf('уникальный%d-%d-токен-заметки', $this->n, $i);
+        }
+
+        return json_encode([
+            'title' => 'Заметка номер ' . $this->n,
+            'body' => implode(' ', $words) . ' и вывод.',
+            'rubric' => 'other',
+        ], JSON_THROW_ON_ERROR);
+    }
+}

--- a/tests/Controller/NewsControllerTest.php
+++ b/tests/Controller/NewsControllerTest.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Controller;
+
+use App\Entity\NewsItem;
+use App\Entity\NewsSource;
+use App\Enum\NewsItemStatus;
+use App\Enum\NewsRubric;
+use App\Enum\TosMode;
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * Публичные страницы /news и /news/{slug}: индексируемость, self-canonical,
+ * обязательная атрибуция «По материалам …» со ссылкой на первоисточник.
+ */
+final class NewsControllerTest extends DatabaseDependentWebTestCase
+{
+    private const SOURCE_NAME = 'Parents.ru';
+    private const SOURCE_URL = 'https://www.parents.ru/news/original-story';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->skipIfNoDatabase();
+        $this->em()->createQuery('DELETE FROM App\Entity\NewsItem')->execute();
+        $this->em()->createQuery('DELETE FROM App\Entity\NewsSource')->execute();
+        static::ensureKernelShutdown();
+    }
+
+    public function testPublishedArticleShowsAttributionAndSelfCanonical(): void
+    {
+        $this->insertItem(NewsItemStatus::Published, 'kapsula-iz-staryh-dzhinsov', 'Капсула из старых джинсов');
+
+        $client = static::createClient();
+        $client->request('GET', '/news/kapsula-iz-staryh-dzhinsov');
+
+        self::assertResponseIsSuccessful();
+        $html = (string) $client->getResponse()->getContent();
+
+        // Атрибуция первоисточника; ссылка постоянная (без nofollow)
+        self::assertStringContainsString('По материалам', $html);
+        self::assertStringContainsString(self::SOURCE_NAME, $html);
+        self::assertStringContainsString('<a href="' . self::SOURCE_URL . '"', $html);
+        self::assertStringNotContainsString('nofollow', $html);
+
+        // Self-canonical + нет noindex
+        // Self-canonical = URL текущей страницы (в тестовом окружении хост — localhost)
+        self::assertStringContainsString('rel="canonical" href="http://localhost/news/kapsula-iz-staryh-dzhinsov"', $html);
+        self::assertStringNotContainsString('noindex', $html);
+
+        self::assertStringContainsString('Капсула из старых джинсов', $html);
+    }
+
+    public function testIndexListsPublishedItems(): void
+    {
+        $this->insertItem(NewsItemStatus::Published, 'novost-pervaya', 'Новость первая');
+        $this->insertItem(NewsItemStatus::Ready, null, 'Черновая новость — не публикуется');
+
+        $client = static::createClient();
+
+        $client->request('GET', '/news');
+        self::assertResponseIsSuccessful();
+        $html = (string) $client->getResponse()->getContent();
+        self::assertStringContainsString('Новость первая', $html);
+        self::assertStringNotContainsString('Черновая новость', $html, 'ready-черновики не видны на сайте');
+        self::assertStringNotContainsString('noindex', $html);
+
+        // Прямой заход на страницу 2 короткой ленты не падает
+        $client->request('GET', '/news?page=2');
+        self::assertResponseIsSuccessful();
+    }
+
+    public function testUnpublishedSlugReturns404(): void
+    {
+        $client = static::createClient();
+        $client->request('GET', '/news/takoj-novosti-net');
+        self::assertResponseStatusCodeSame(404);
+    }
+
+    private function insertItem(NewsItemStatus $status, ?string $slug, string $title): void
+    {
+        $em = $this->em();
+        $source = $em->getRepository(NewsSource::class)->findOneBy(['name' => self::SOURCE_NAME]);
+        if ($source === null) {
+            $source = (new NewsSource())
+                ->setName(self::SOURCE_NAME)
+                ->setFeedUrl('https://www.parents.test/rss.xml')
+                ->setTosMode(TosMode::FactsOnly)
+                ->setActive(true);
+            $em->persist($source);
+            $em->flush();
+        }
+
+        static $seq = 0;
+        ++$seq;
+
+        $item = (new NewsItem())
+            ->setSource($source)
+            ->setGuidHash('hash-' . $seq . '-' . bin2hex(random_bytes(4)))
+            ->setUrl(self::SOURCE_URL)
+            ->setTitle('Оригинальный заголовок ' . $seq)
+            ->setSourceName(self::SOURCE_NAME)
+            ->setSourceUrl(self::SOURCE_URL)
+            ->setRewrittenTitle($title)
+            ->setRewrittenBody("Первый абзац заметки про гардероб.\n\nВторой абзац с фактами.")
+            ->setRubric(NewsRubric::Wardrobe)
+            ->setStatus($status);
+        if ($slug !== null && $status === NewsItemStatus::Published) {
+            $item->setSlug($slug);
+        }
+        $em->persist($item);
+        $em->flush();
+
+        // Данные в файловой SQLite переживают shutdown; createClient требует незагруженный kernel.
+        static::ensureKernelShutdown();
+    }
+
+    private function em(): EntityManagerInterface
+    {
+        return static::getContainer()->get('doctrine.orm.entity_manager');
+    }
+}


### PR DESCRIPTION
- **feat(news): сущности news_source/news_item и миграция конвейера новостей**
- **feat(news): fetch-шаг конвейера — RSS, дедуп, вежливость 1 req/sec**
- **feat(news): process-шаг — догрузка статьи, LLM-рерайт, шингл-гейт, кап 8/день**
- **feat(news): модерация в админке и публичные страницы /news**
- **test(news): конвейер — дедуп, forbidden-skip, шингл-гейт, кап, LLM-fallback**
