### PR TITLE
feat(wardrobe): поворот фото ↻/↺ без перезагрузки

### DIFF
--- a/src/Controller/Account/WardrobeController.php
+++ b/src/Controller/Account/WardrobeController.php
@@ -203,6 +203,34 @@ class WardrobeController extends AbstractController
         return $this->redirectToRoute('account_wardrobe_show', ['id' => $id] + $this->memberQuery($user, $currentMember));
     }
 
+    #[Route('/{id}/photos/{photoId}/rotate', name: 'photo_rotate', requirements: ['id' => '\d+', 'photoId' => '\d+'], methods: ['POST'])]
+    public function rotatePhoto(
+        int $id,
+        int $photoId,
+        Request $request,
+        WardrobeItemRepository $repo,
+        EntityManagerInterface $em,
+    ): Response {
+        [$user, $currentMember, $item, $photo] = $this->resolvePhotoAction($id, $photoId, $request, $repo, $em);
+        if (!$this->isCsrfTokenValid('wardrobe_photo_'.$photoId, $request->request->get('_token'))) {
+            return $this->json(['ok' => false, 'error' => 'Недействительный токен'], Response::HTTP_FORBIDDEN);
+        }
+        $degrees = $request->request->getInt('degrees');
+        if (!in_array($degrees, [90, -90], true)) {
+            return $this->json(['ok' => false, 'error' => 'Неверный угол'], Response::HTTP_BAD_REQUEST);
+        }
+        try {
+            $this->photoManager->rotate($photo, $degrees);
+        } catch (\InvalidArgumentException|\RuntimeException $exception) {
+            return $this->json(['ok' => false, 'error' => $exception->getMessage()], Response::HTTP_UNPROCESSABLE_ENTITY);
+        }
+
+        return $this->json([
+            'ok' => true,
+            'uri' => $this->generateUrl('account_wardrobe_media_photo', ['id' => $photo->getId()]).'?v='.$photo->getUpdatedAt()->getTimestamp(),
+        ]);
+    }
+
     #[Route('/{id}/archive', name: 'archive', requirements: ['id' => '\d+'], methods: ['POST'])]
     public function archive(int $id, Request $request, WardrobeItemRepository $repo): Response
     {

--- a/src/Service/Wardrobe/WardrobePhotoManager.php
+++ b/src/Service/Wardrobe/WardrobePhotoManager.php
@@ -8,6 +8,7 @@ use App\Entity\WardrobeItem;
 use App\Entity\WardrobeItemPhoto;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Vich\UploaderBundle\Storage\StorageInterface;
 
 final class WardrobePhotoManager
 {
@@ -15,7 +16,11 @@ final class WardrobePhotoManager
     private const MAX_FILE_SIZE = 10_000_000;
     private const MAX_BATCH_SIZE = 8;
 
-    public function __construct(private readonly EntityManagerInterface $entityManager, private readonly WardrobeImageSanitizer $sanitizer) {}
+    public function __construct(
+        private readonly EntityManagerInterface $entityManager,
+        private readonly WardrobeImageSanitizer $sanitizer,
+        private readonly StorageInterface $storage,
+    ) {}
 
     /** @param UploadedFile[] $files
      *  @return WardrobeItemPhoto[]
@@ -101,6 +106,32 @@ final class WardrobePhotoManager
             $next?->setIsCover(true);
             $item->setPhoto($next?->getFilePath());
         }
+        $this->entityManager->flush();
+    }
+
+    public function rotate(WardrobeItemPhoto $photo, int $degrees): void
+    {
+        if ($photo->isDeleted()) {
+            throw new \InvalidArgumentException('Фотография уже удалена.');
+        }
+        $path = $this->storage->resolvePath($photo, 'file');
+        if ($path === null || !is_file($path)) {
+            throw new \InvalidArgumentException('Файл фото не найден.');
+        }
+        $raw = file_get_contents($path);
+        $image = is_string($raw) ? @imagecreatefromstring($raw) : false;
+        if ($image === false) {
+            throw new \RuntimeException('Не удалось прочитать изображение.');
+        }
+        $rotated = imagerotate($image, -$degrees, 0);
+        imagedestroy($image);
+        if ($rotated === false || !imagejpeg($rotated, $path, 90)) {
+            imagedestroy($rotated);
+            throw new \RuntimeException('Не удалось повернуть изображение.');
+        }
+        imagedestroy($rotated);
+        $photo->setFileSize((int) filesize($path))
+            ->setUpdatedAt(new \DateTimeImmutable());
         $this->entityManager->flush();
     }
 

--- a/templates/account/wardrobe/show.html.twig
+++ b/templates/account/wardrobe/show.html.twig
@@ -83,7 +83,8 @@
     <div class="md:col-span-5">
         <div class="overflow-hidden rounded-2xl bg-white shadow-sm">
             {% if item.coverPhoto %}
-                <img src="{{ path('account_wardrobe_media_photo', {id: item.coverPhoto.id}) }}"
+                <img data-rotate-cover="1"
+                     src="{{ path('account_wardrobe_media_photo', {id: item.coverPhoto.id}) }}"
                      class="aspect-square w-full object-cover" alt="{{ item.name }}">
             {% elseif item.photo %}
                 <img src="{{ path('account_wardrobe_media_item', {id: item.id}) }}"
@@ -92,13 +93,23 @@
                 <div class="flex aspect-square w-full items-center justify-center bg-gray-100 text-6xl opacity-20">👕</div>
             {% endif %}
         </div>
+        {% if mayManage and item.coverPhoto %}
+        <div class="mt-1 flex justify-center gap-1">
+            <button type="button" data-rotate-btn="{{ item.coverPhoto.id }}" data-degrees="90" data-url="{{ path('account_wardrobe_photo_rotate', {id: item.id, photoId: item.coverPhoto.id}|merge(memberParam)) }}" data-token="{{ csrf_token('wardrobe_photo_' ~ item.coverPhoto.id) }}" class="rounded px-3 py-1 text-xs font-semibold text-gray-500 hover:text-gray-900 transition">↻ Вправо</button>
+            <button type="button" data-rotate-btn="{{ item.coverPhoto.id }}" data-degrees="-90" data-url="{{ path('account_wardrobe_photo_rotate', {id: item.id, photoId: item.coverPhoto.id}|merge(memberParam)) }}" data-token="{{ csrf_token('wardrobe_photo_' ~ item.coverPhoto.id) }}" class="rounded px-3 py-1 text-xs font-semibold text-gray-500 hover:text-gray-900 transition">↺ Влево</button>
+        </div>
+        {% endif %}
 
         {% if item.activePhotos|length > 0 %}
         <div class="mt-3 grid grid-cols-3 gap-2">
             {% for photo in item.activePhotos %}
             <div class="overflow-hidden rounded-xl bg-white p-1.5 shadow-sm">
-                <img src="{{ path('account_wardrobe_media_photo', {id: photo.id}) }}" class="aspect-square w-full rounded-lg object-cover" alt="">
-                <div class="mt-1 flex gap-1">
+                <img data-rotate-target="{{ photo.id }}"
+                     src="{{ path('account_wardrobe_media_photo', {id: photo.id}) }}" class="aspect-square w-full rounded-lg object-cover" alt="">
+                {% if mayManage %}
+                <div class="mt-1 flex gap-0.5">
+                    <button type="button" data-rotate-btn="{{ photo.id }}" data-degrees="90" data-url="{{ path('account_wardrobe_photo_rotate', {id: item.id, photoId: photo.id}|merge(memberParam)) }}" data-token="{{ csrf_token('wardrobe_photo_' ~ photo.id) }}" class="flex-1 px-1 py-1 text-[10px] font-semibold text-gray-500 hover:text-gray-900 transition">↻</button>
+                    <button type="button" data-rotate-btn="{{ photo.id }}" data-degrees="-90" data-url="{{ path('account_wardrobe_photo_rotate', {id: item.id, photoId: photo.id}|merge(memberParam)) }}" data-token="{{ csrf_token('wardrobe_photo_' ~ photo.id) }}" class="flex-1 px-1 py-1 text-[10px] font-semibold text-gray-500 hover:text-gray-900 transition">↺</button>
                     {% if photo.cover %}
                         <span class="flex-1 px-1 py-1 text-center text-[10px] font-semibold text-emerald-700">Обложка</span>
                     {% else %}
@@ -113,6 +124,7 @@
                         <button class="px-1 py-1 text-[10px] text-red-500" aria-label="Убрать фото">×</button>
                     </form>
                 </div>
+                {% endif %}
             </div>
             {% endfor %}
         </div>
@@ -340,4 +352,37 @@
         {% endif %}
     </div>
 </div>
+<script>
+(function () {
+    document.querySelectorAll('[data-rotate-btn]').forEach(function (btn) {
+        btn.addEventListener('click', function () {
+            var id = btn.getAttribute('data-rotate-btn');
+            var degrees = btn.getAttribute('data-degrees');
+            var url = btn.getAttribute('data-url');
+            var token = btn.getAttribute('data-token');
+            btn.disabled = true;
+            fetch(url, {
+                method: 'POST',
+                headers: {'Content-Type': 'application/x-www-form-urlencoded', 'X-Requested-With': 'XMLHttpRequest'},
+                body: '_token=' + encodeURIComponent(token) + '&degrees=' + degrees
+            }).then(function (r) { return r.json(); }).then(function (data) {
+                if (data.ok) {
+                    document.querySelectorAll('[data-rotate-target="' + id + '"]').forEach(function (img) {
+                        img.src = data.uri;
+                    });
+                    if (document.querySelector('[data-rotate-cover="1"]')) {
+                        document.querySelector('[data-rotate-cover="1"]').src = data.uri;
+                    }
+                } else {
+                    alert(data.error || 'Ошибка поворота');
+                }
+            })['catch'](function () {
+                alert('Сеть недоступна');
+            })['finally'](function () {
+                btn.disabled = false;
+            });
+        });
+    });
+})();
+</script>
 {% endblock %}

--- a/tests/Controller/WardrobeControllerTest.php
+++ b/tests/Controller/WardrobeControllerTest.php
@@ -777,6 +777,131 @@ class WardrobeControllerTest extends AuthenticatedWebTestCase
         $this->assertNull($stillActive->getDeletedAt());
     }
 
+    public function testRotatePhotoReturnsJsonAndRotatesFile(): void
+    {
+        $client = static::createClient();
+        $user = $this->loginAsCustomer($client);
+        /** @var EntityManagerInterface $em */
+        $em = static::getContainer()->get('doctrine.orm.entity_manager');
+        /** @var StorageInterface $storage */
+        $storage = static::getContainer()->get(StorageInterface::class);
+
+        [$item, $photo1] = $this->createItemWithTwoPhotos($em, $user, 600);
+        $id = $item->getId();
+
+        $absPath = $storage->resolvePath($photo1, 'file');
+        @mkdir(dirname($absPath), 0777, true);
+        $im = imagecreatetruecolor(8, 4);
+        imagejpeg($im, $absPath, 90);
+        imagedestroy($im);
+        $this->tmpFiles[] = $absPath;
+        $originalSize = filesize($absPath);
+        $photo1->setFileSize($originalSize)->setUpdatedAt(new \DateTimeImmutable('2020-01-01'));
+        $em->flush();
+
+        $client->request('GET', '/account/wardrobe/' . $id);
+        $token = $this->forceCsrfToken($client->getRequest(), 'wardrobe_photo_' . $photo1->getId());
+
+        $client->request(
+            'POST',
+            '/account/wardrobe/' . $id . '/photos/' . $photo1->getId() . '/rotate',
+            ['_token' => $token, 'degrees' => '90'],
+            [],
+            ['HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest'],
+        );
+        $this->assertResponseIsSuccessful();
+        $data = json_decode($client->getResponse()->getContent(), true);
+        $this->assertTrue($data['ok']);
+        $this->assertStringContainsString('v=', $data['uri']);
+
+        $imNew = @imagecreatefromstring(file_get_contents($absPath));
+        $this->assertNotFalse($imNew);
+        $this->assertSame(4, imagesx($imNew));
+        $this->assertSame(8, imagesy($imNew));
+        imagedestroy($imNew);
+
+        $em->clear();
+        /** @var WardrobeItemPhoto $reloaded */
+        $reloaded = $em->find(WardrobeItemPhoto::class, $photo1->getId());
+        $this->assertNotNull($reloaded->getFileSize());
+        $this->assertNotSame('2020-01-01', $reloaded->getUpdatedAt()->format('Y-m-d'));
+    }
+
+    public function testRotatePhotoWithInvalidCsrfReturns403(): void
+    {
+        $client = static::createClient();
+        $user = $this->loginAsCustomer($client);
+        /** @var EntityManagerInterface $em */
+        $em = static::getContainer()->get('doctrine.orm.entity_manager');
+
+        [$item, $photo1] = $this->createItemWithTwoPhotos($em, $user, 601);
+
+        $client->request(
+            'POST',
+            '/account/wardrobe/' . $item->getId() . '/photos/' . $photo1->getId() . '/rotate',
+            ['_token' => 'bad-token', 'degrees' => '90'],
+            [],
+            ['HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest'],
+        );
+        $this->assertResponseStatusCodeSame(403);
+    }
+
+    public function testRotatePhotoReturns404ForForeignItem(): void
+    {
+        $client = static::createClient();
+        $user = $this->loginAsCustomer($client);
+        /** @var EntityManagerInterface $em */
+        $em = static::getContainer()->get('doctrine.orm.entity_manager');
+
+        [$foreignItem, $foreignPhoto] = $this->createItemWithTwoPhotos($em, UserFactory::brandOwner(static::getContainer()), 602);
+
+        $client->request(
+            'POST',
+            '/account/wardrobe/' . $foreignItem->getId() . '/photos/' . $foreignPhoto->getId() . '/rotate',
+            ['_token' => 'x', 'degrees' => '90'],
+            [],
+            ['HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest'],
+        );
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    public function testRotatePhotoRejectsInvalidDegrees(): void
+    {
+        $client = static::createClient();
+        $user = $this->loginAsCustomer($client);
+        /** @var EntityManagerInterface $em */
+        $em = static::getContainer()->get('doctrine.orm.entity_manager');
+
+        [$item, $photo1] = $this->createItemWithTwoPhotos($em, $user, 603);
+
+        $client->request('GET', '/account/wardrobe/' . $item->getId());
+        $token = $this->forceCsrfToken($client->getRequest(), 'wardrobe_photo_' . $photo1->getId());
+
+        $client->request(
+            'POST',
+            '/account/wardrobe/' . $item->getId() . '/photos/' . $photo1->getId() . '/rotate',
+            ['_token' => $token, 'degrees' => '45'],
+            [],
+            ['HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest'],
+        );
+        $this->assertResponseStatusCodeSame(400);
+    }
+
+    public function testShowPageContainsRotateButtonsForGalleryPhotos(): void
+    {
+        $client = static::createClient();
+        $user = $this->loginAsCustomer($client);
+        /** @var EntityManagerInterface $em */
+        $em = static::getContainer()->get('doctrine.orm.entity_manager');
+
+        [$item, $photo1] = $this->createItemWithTwoPhotos($em, $user, 604);
+
+        $crawler = $client->request('GET', '/account/wardrobe/' . $item->getId());
+        $this->assertResponseIsSuccessful();
+        $this->assertGreaterThanOrEqual(2, $crawler->filter('[data-rotate-btn]')->count());
+        $this->assertGreaterThanOrEqual(2, $crawler->filter('[data-rotate-target]')->count());
+    }
+
     /**
      * Регресс на 🔴: раньше замена photoFile через «Редактировать» физически удаляла
      * старый файл (Vich delete_on_update) и не заводила для него строку галереи —


### PR DESCRIPTION
- WardrobePhotoManager::rotate() — GD imagerotate ±90°, flush fileSize/updatedAt
- WardrobeController::rotatePhoto() — POST JSON, CSRF, валидация угла
- show.html.twig — кнопки рядом с каждым фото (галерея + обложка), AJAX JS
- 5 тестов: success + invalid CSRF + IDOR + invalid degrees + кнопки на странице
